### PR TITLE
fix: prevent runaway memory/disk use and assistant/TTS issues

### DIFF
--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -1,0 +1,177 @@
+# Future work / deferred improvements
+
+This file tracks known-good improvements that are intentionally **deferred** so
+we can ship the crash/memory/UX fixes first without a large architectural
+change. Nothing here is a blocker for the current fixes; each item is safe to
+pick up independently later.
+
+Context: a set of stability fixes landed to stop the "memory climbs → disk hits
+100% → PC freezes/shuts down" failure, the "can't stop the assistant while it's
+transcribing / loading a reply" problem, and the TTS "download again every time"
+annoyance. See the commit history / PR for those. The items below are what we
+consciously chose **not** to do yet.
+
+---
+
+## 1. Move local TTS (Kokoro) from the WebView to the Rust backend
+
+**Status:** deferred. We keep the current in-WebView Kokoro (`kokoro-js`) for now
+because it works cross-platform with zero extra build/runtime setup and is fast
+enough on machines with working WebGPU.
+
+**Interim fix applied (Windows):** every window is now created with
+`--enable-unsafe-webgpu` (and `--autoplay-policy=no-user-gesture-required`) via
+`WEBVIEW2_BROWSER_ARGS` in `lib.rs`, so on Windows with a WebGPU-capable
+GPU/driver kokoro-js runs fp32 on the GPU instead of the robotic wasm/q8
+fallback, and spoken replies aren't blocked by autoplay. This does NOT help
+macOS/Linux (their webviews can't enable WebGPU flags) — those still use the
+wasm fallback, which is the main remaining reason to do the backend migration.
+
+### Why the current approach is the weak link
+
+Local TTS currently runs the Kokoro-82M model **inside the assistant panel's
+WebView** via [`kokoro-js`](https://www.npmjs.com/package/kokoro-js)
+(onnxruntime-web, WebGPU with a wasm fallback). See
+`src/assistant/useKokoroTts.ts`. The backend `src-tauri/src/tts.rs` only handles
+**network** engines (OpenAI-compatible, ElevenLabs, Azure, and local HTTP
+servers such as Kokoro-FastAPI / openai-edge-tts). Its module header notes: the
+"kokoro" engine runs fully locally in the panel webview and never reaches that
+module.
+
+This causes several problems at once:
+
+- **Robotic audio.** Tauri WebViews frequently lack working WebGPU (Windows
+  WebView2 is flaky; macOS WKWebView / Linux WebKitGTK generally have none), so
+  `useKokoroTts.ts` silently falls back to `device: "wasm"` and downgrades
+  precision to `q8`. wasm + q8 is slower and lower quality — the "robotic" sound.
+- **Sometimes no audio at all.** First use must download the model from
+  HuggingFace (fails offline / behind a proxy), and browser autoplay can be
+  blocked (`NotAllowedError`) until a user gesture in the panel window.
+- **Contributes to the WebView memory leak.** The onnxruntime session and its
+  WebGPU buffers (hundreds of MB) are not reliably released. (A best-effort
+  dispose/blob-revoke fix was applied, but the underlying wry `evaluate_script`
+  leak — see item 6 — still makes the WebView the worst place to hold a large
+  model.)
+- **Confusing download state.** Kokoro is downloaded/cached by the browser
+  (transformers.js cache), which is a completely separate system from the
+  disk-backed model store (`managers/model.rs`) used by STT/LLM models. The two
+  never reconcile.
+
+### Target architecture
+
+Run Kokoro natively in Rust, next to how STT/VAD already work, and play through
+the existing `rodio` pipeline in `tts.rs`.
+
+We already ship an ONNX runtime in the backend: `transcribe-rs` is built with the
+`onnx` feature and `vad-rs` (Silero) is ONNX-based, and `tts.rs` already plays
+audio with `rodio`. So a native Kokoro engine is consistent with the existing
+stack.
+
+Options, roughly by effort:
+
+1. **Native backend Kokoro (recommended).** Load Kokoro-82M ONNX in Rust via the
+   `ort` crate (ONNX Runtime) with a GPU execution provider where available
+   (DirectML on Windows, CoreML on macOS, CUDA on Linux) and CPU otherwise;
+   synthesize to PCM and play via `rodio`. Fixes robotic + snappiness + autoplay,
+   unifies the download with `model.rs`, and removes a WebView leak source. This
+   also needs a phonemizer (Kokoro expects phonemes); evaluate `espeak-ng`
+   bindings or a bundled G2P.
+2. **Local HTTP server (already supported).** `tts.rs` already speaks to
+   Kokoro-FastAPI / openai-edge-tts. Zero new Rust, but the user must run a
+   separate server — a power-user option, not a good default.
+3. **OS-native TTS as an instant fallback.** Windows SAPI /
+   `System.Speech`, macOS `AVSpeechSynthesizer`, Linux `speech-dispatcher`.
+   Instant, no download, no leak, but more robotic than Kokoro. Good as the
+   default fallback when there is no GPU/model.
+
+### Suggested path
+
+Short term: add OS-native TTS (option 3) as a "just works" fallback. Medium term:
+build the native backend Kokoro (option 1) and retire the WebView path. Until
+then the WebView Kokoro remains the default; keep the leak mitigations in
+`useKokoroTts.ts`.
+
+---
+
+## 2. Engine child crash-safety on macOS / Linux
+
+**Status:** partially covered. The Windows orphan problem is fixed with a
+kill-on-close **Job Object** (`managers/local_llm.rs`) plus graceful
+`RunEvent::Exit` cleanup in `lib.rs` (all platforms).
+
+On **Linux**, add crash-safety parity by setting `PR_SET_PDEATHSIG` (e.g.
+`SIGKILL`) on the child via `CommandExt::pre_exec` so the engine dies if the
+parent dies unexpectedly. On **macOS** there is no direct equivalent; the
+`RunEvent::Exit` handler covers graceful quit, and a hard kill is rarer, but a
+watchdog or a `kqueue`-based parent-death check could close the gap.
+
+## 3. Startup reaping of a stale engine
+
+**Status:** deferred. Users upgrading from a build that pre-dates the Job Object
+fix may have one leftover `llama-server.exe` from a previous session. Consider a
+conservative, one-time startup check that reaps only an engine we can positively
+identify as ours (e.g. bound to our loopback port `11435` and matching our
+binary path) — being careful never to kill a user's own Ollama/llama.cpp.
+
+## 4. Remote PCM TTS sample-rate handling (`tts.rs`)
+
+**Status:** deferred (only affects OpenAI-compatible endpoints that return raw
+PCM without a `rate=` in the Content-Type). Today the code assumes
+`PCM_DEFAULT_SAMPLE_RATE = 24_000`, so a provider returning 16k/48k PCM plays at
+the wrong speed (chipmunk/robotic). Make the assumed rate configurable per TTS
+provider, or detect it, instead of hard-defaulting to 24 kHz.
+
+## 5. Unify the two model-download surfaces
+
+**Status:** deferred. STT/LLM models are disk-backed (`managers/model.rs`,
+reflected by `is_downloaded`), while Kokoro TTS is browser-cached by
+transformers.js. The Models tab and the assistant TTS settings therefore can
+disagree about whether "the TTS model" is downloaded. A robust readiness check
+against the browser cache was added as a stopgap; fully unifying these (ideally
+by moving Kokoro to the backend per item 1) is the real fix.
+
+## 6. WebView IPC volume / the upstream wry `evaluate_script` leak
+
+**Status:** mitigated, not eliminated. The root cause is upstream
+([tauri-apps/wry#1489](https://github.com/tauri-apps/wry/issues/1489); WebView2
+equivalent [tauri-apps/tauri#12724](https://github.com/tauri-apps/tauri/issues/12724)):
+`evaluate_script` leaks a little memory per call and never releases it. We
+reduced our call volume (throttling `mic-level` to ~30 FPS — the Handy #1279
+fix — and coalescing per-token `assistant-token` emits). Revisit if/when the
+upstream leak is fixed, and audit for any other high-frequency emitters.
+
+## 7. Assistant conversation persistence cost
+
+**Status:** deferred. `managers/history.rs` re-serializes and rewrites the
+**entire** conversation (including base64 image thumbnails) to SQLite on every
+turn — O(n²) writes over a long image-heavy chat, adding disk I/O. Consider
+append-only message writes or debounced/dirty-only persistence. Also consider
+trimming the in-memory `AssistantConversation.messages` for very long sessions.
+
+## 8. Remaining cancellation edge cases
+
+**Status:** partially fixed. The reply/streaming phase is cancellable
+(`tokio::select!` vs the cancel `Notify`), the built-in model-load phase is now
+cancellable too (`run_assistant_turn` races `ensure_running` against a Stop),
+and a hung stream now self-cancels via the SSE stall timeout. The frontend also
+now exposes a real cancel (✗) during listening/transcribing wired to
+`cancel_current_operation`.
+
+Two narrow gaps remain, deliberately deferred to avoid regressions in the
+recording pipeline:
+
+- **STT-window race.** `run_assistant_turn` calls `begin_turn()` which clears
+  the sticky `cancelled` flag (so a _stale_ Stop from a previous turn can't
+  suppress a new one). A Stop pressed during the brief batch-transcription
+  window (after the hotkey is released, before the reply starts) sets the flag,
+  which `begin_turn()` then clears — so that specific Stop can be lost and the
+  reply proceeds. Cancelling during _recording_ (the common case) already works
+  because it aborts the recording before STT. A clean fix is to clear the flag
+  at voice-capture start (recording start) instead of at turn start, then bail
+  in `run_voice_turn` if cancelled — but that touches the shared recording path
+  and needs careful testing.
+- **Batch STT is not abortable mid-inference.** `tm.transcribe()` runs to
+  completion; `tm.cancel_stream()` only affects the live/streaming worker. A
+  Stop during a long Whisper batch pass won't interrupt the pass itself (it just
+  prevents the subsequent reply). Making batch inference cancellable would need
+  support in the transcription engine.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -109,6 +109,10 @@ windows = { version = "0.61.3", features = [
   "Win32_System_Variant",
   "Win32_Foundation",
   "Win32_UI_WindowsAndMessaging",
+  # Job Objects: tie the bundled llama-server child to the app's lifetime so it
+  # is killed on crash/force-kill (orphan-process cleanup, see local_llm.rs).
+  "Win32_System_JobObjects",
+  "Win32_Security",
 ] }
 winreg = "0.55"
 

--- a/src-tauri/src/assistant.rs
+++ b/src-tauri/src/assistant.rs
@@ -967,6 +967,10 @@ pub fn create_assistant_panel(app: &AppHandle) {
         PANEL_LABEL,
         tauri::WebviewUrl::App("src/assistant/index.html".into()),
     )
+    // Enables WebGPU (fp32 Kokoro TTS instead of the robotic wasm/q8 fallback)
+    // and no-gesture autoplay for spoken replies. Must match every other
+    // window's args (see WEBVIEW2_BROWSER_ARGS). Windows/WebView2 only.
+    .additional_browser_args(crate::WEBVIEW2_BROWSER_ARGS)
     .title("Assistant")
     .inner_size(init_w, init_h)
     .min_inner_size(PILL_WIDTH, PILL_HEIGHT)
@@ -1310,6 +1314,9 @@ pub fn open_snip_overlay(
         SNIP_LABEL,
         tauri::WebviewUrl::App("src/assistant/snip.html".into()),
     )
+    // Must match every other window's args (see WEBVIEW2_BROWSER_ARGS).
+    // Windows/WebView2 only.
+    .additional_browser_args(crate::WEBVIEW2_BROWSER_ARGS)
     .title("Snip")
     .inner_size(logical_w, logical_h)
     .position(logical_x, logical_y)
@@ -2245,9 +2252,31 @@ pub async fn run_assistant_turn(
     // Built-in provider: ensure the engine is running, then hold an activity
     // guard across the streamed turn so the idle watcher won't unload it
     // mid-generation.
+    // Acquire the cancel handle up front so the pre-stream phases (model load)
+    // are cancellable too — not only the streaming phase further below.
+    let cancel = {
+        let conversation = app.state::<AssistantConversation>();
+        conversation.cancel.clone()
+    };
+
     let _llm_activity_guard = if provider.id == "builtin" {
         let manager = app.state::<Arc<crate::managers::local_llm::LocalLlmManager>>();
-        if let Err(e) = manager.ensure_running(&model).await {
+        // Race the (possibly long) model load / first-run GPU shader compile
+        // against a Stop, so the user isn't stuck on "thinking" with no way to
+        // cancel while the built-in engine spins up (up to READY_TIMEOUT).
+        let load_result = {
+            let ensure = manager.ensure_running(&model);
+            tokio::pin!(ensure);
+            tokio::select! {
+                res = &mut ensure => res,
+                _ = cancel.notified() => {
+                    debug!("Assistant turn cancelled during engine load");
+                    emit_state(&app, "idle");
+                    return;
+                }
+            }
+        };
+        if let Err(e) = load_result {
             emit_error(&app, "engine_start", e.to_string());
             emit_state(&app, "idle");
             return;
@@ -2265,11 +2294,6 @@ pub async fn run_assistant_turn(
         visuals.len(),
         files.len()
     );
-
-    let cancel = {
-        let conversation = app.state::<AssistantConversation>();
-        conversation.cancel.clone()
-    };
 
     // Accumulate streamed tokens so a cancelled turn can keep the partial reply.
     let partial = Arc::new(Mutex::new(String::new()));
@@ -2320,8 +2344,6 @@ pub async fn run_assistant_turn(
                 // The model alone decides whether to call a tool; we never
                 // force one.
                 let tool_choice = json!("auto");
-                let po = partial_cb.clone();
-                let ao = app_tokens.clone();
                 let round_out = llm_client::send_chat_stream_with_tools(
                     &provider_c,
                     api_key_c.clone(),
@@ -2331,12 +2353,7 @@ pub async fn run_assistant_turn(
                     tool_choice,
                     None,
                     None,
-                    move |token| {
-                        if let Ok(mut buf) = po.lock() {
-                            buf.push_str(token);
-                        }
-                        let _ = ao.emit("assistant-token", token.to_string());
-                    },
+                    assistant_token_sink(app_tokens.clone(), partial_cb.clone()),
                 )
                 .await?;
                 let round_policy = tool_round_policy(&round_out, round_index);
@@ -2458,8 +2475,6 @@ pub async fn run_assistant_turn(
             _ = cancel.notified() => None,
         }
     } else {
-        let partial_cb = partial.clone();
-        let app_for_tokens = app.clone();
         let stream_fut = llm_client::send_chat_stream(
             &provider,
             api_key.clone(),
@@ -2467,12 +2482,7 @@ pub async fn run_assistant_turn(
             messages,
             None,
             None,
-            move |token| {
-                if let Ok(mut buf) = partial_cb.lock() {
-                    buf.push_str(token);
-                }
-                let _ = app_for_tokens.emit("assistant-token", token.to_string());
-            },
+            assistant_token_sink(app.clone(), partial.clone()),
         );
         tokio::pin!(stream_fut);
         // Race the stream against a Stop request. notify_waiters wakes this select.
@@ -2749,8 +2759,6 @@ pub async fn run_summarize_turn(app: AppHandle) {
 
     let cancel = app.state::<AssistantConversation>().cancel.clone();
     let partial = Arc::new(Mutex::new(String::new()));
-    let partial_cb = partial.clone();
-    let app_for_tokens = app.clone();
     let stream_fut = llm_client::send_chat_stream(
         &provider,
         api_key,
@@ -2758,12 +2766,7 @@ pub async fn run_summarize_turn(app: AppHandle) {
         messages,
         None,
         None,
-        move |token| {
-            if let Ok(mut buf) = partial_cb.lock() {
-                buf.push_str(token);
-            }
-            let _ = app_for_tokens.emit("assistant-token", token.to_string());
-        },
+        assistant_token_sink(app.clone(), partial.clone()),
     );
     tokio::pin!(stream_fut);
 
@@ -3307,5 +3310,33 @@ mod tests {
         assert!(conversation.is_cancelled());
         conversation.begin_turn();
         assert!(!conversation.is_cancelled());
+    }
+}
+
+/// Build an `on_token` sink for a streamed assistant reply.
+///
+/// It (1) accumulates the full text into `partial` so a cancelled turn keeps
+/// what was generated, and (2) forwards text to the panel via `assistant-token`,
+/// COALESCED to at most one emit per ~40ms. Each emit becomes an
+/// `evaluate_script` call in the panel WebView, and wry's `evaluate_script`
+/// leaks memory per call upstream (tauri-apps/wry#1489); batching cuts that
+/// volume on fast streams. Any sub-40ms tail left unflushed is harmless: the
+/// turn ends by emitting the authoritative full conversation
+/// (`emit_conversation`), which the panel uses to replace the streamed text and
+/// reset its stream buffer.
+fn assistant_token_sink(app: tauri::AppHandle, partial: Arc<Mutex<String>>) -> impl FnMut(&str) {
+    use std::time::Instant;
+    const FLUSH_INTERVAL_MS: u128 = 40;
+    let mut pending = String::new();
+    let mut last_flush = Instant::now();
+    move |token: &str| {
+        if let Ok(mut buf) = partial.lock() {
+            buf.push_str(token);
+        }
+        pending.push_str(token);
+        if last_flush.elapsed().as_millis() >= FLUSH_INTERVAL_MS {
+            let _ = app.emit("assistant-token", std::mem::take(&mut pending));
+            last_flush = Instant::now();
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,26 @@ mod utils;
 mod web_search;
 
 pub use cli::CliArgs;
+
+/// WebView2 (Windows) browser arguments, applied IDENTICALLY to every window.
+///
+/// Why identical on every window: `wry` creates a WebView2 environment per
+/// window sharing one user-data directory, and WebView2 refuses to create a
+/// window whose browser args differ from an existing environment on the same
+/// directory. So every `WebviewWindowBuilder` in this app MUST pass exactly this
+/// string via `.additional_browser_args(crate::WEBVIEW2_BROWSER_ARGS)`.
+///
+/// - Preserves wry's defaults (`--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`),
+///   which `additional_browser_args` would otherwise REPLACE.
+/// - `--enable-unsafe-webgpu` lets the in-panel Kokoro TTS run on the GPU (fp32)
+///   instead of the robotic wasm/q8 fallback. If the GPU/driver can't do WebGPU,
+///   kokoro-js safely falls back to wasm exactly as before (no regression).
+/// - `--autoplay-policy=no-user-gesture-required` lets a spoken reply start
+///   without a prior click (otherwise the WebView blocks TTS audio silently).
+///
+/// Has no effect on macOS (WKWebView) or Linux (WebKitGTK) — those backends
+/// ignore this attribute — so it is safe to pass unconditionally.
+pub const WEBVIEW2_BROWSER_ARGS: &str = "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --enable-unsafe-webgpu --autoplay-policy=no-user-gesture-required";
 #[cfg(debug_assertions)]
 use specta_typescript::{BigIntExportBehavior, Typescript};
 use tauri_specta::{collect_commands, collect_events, Builder};
@@ -796,6 +816,9 @@ pub fn run(cli_args: CliArgs) {
             // for portable mode (redirects WebView2 cache to portable Data dir)
             let mut win_builder =
                 tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("/".into()))
+                    // WebView2 args shared identically across every window (see
+                    // WEBVIEW2_BROWSER_ARGS). Windows-only effect.
+                    .additional_browser_args(crate::WEBVIEW2_BROWSER_ARGS)
                     // Empty title + a blanked caption icon (see
                     // tray::update_window_icon) keep the top of the window clear
                     // — no "SpeakoFlow" text and no logo in the title bar.
@@ -997,6 +1020,20 @@ pub fn run(cli_args: CliArgs) {
             #[cfg(target_os = "macos")]
             if let tauri::RunEvent::Reopen { .. } = &event {
                 show_main_window(app);
+            }
+            // Tear down the built-in LLM sidecar on quit. `app.exit()` calls
+            // `std::process::exit`, which skips `Drop` (and everything after
+            // `.run()`), so without this the multi-GB `llama-server` child is
+            // orphaned on every graceful quit and accumulates across relaunches
+            // until RAM is exhausted (memory climbs -> disk/swap 100% -> freeze).
+            // The Windows Job Object in `local_llm.rs` is the backstop for the
+            // crash / hard-kill paths where even this handler cannot run.
+            if let tauri::RunEvent::Exit = &event {
+                if let Some(mgr) =
+                    app.try_state::<std::sync::Arc<managers::local_llm::LocalLlmManager>>()
+                {
+                    mgr.stop();
+                }
             }
             let _ = (app, event); // suppress unused warnings on non-macOS
         });

--- a/src-tauri/src/llm_client.rs
+++ b/src-tauri/src/llm_client.rs
@@ -202,6 +202,12 @@ fn create_client(provider: &PostProcessProvider, api_key: &str) -> Result<reqwes
         // (Azure) on large bodies, e.g. multi-hundred-KB image payloads
         // arriving truncated ("Unterminated string" 400s).
         .http1_only()
+        // Bound connection setup so an unreachable/hung host fails fast instead
+        // of leaving a turn pending forever (which would pin the built-in
+        // engine's in-flight guard and block idle-unload). Intentionally NOT an
+        // overall `.timeout()`: that would abort long, legitimate streaming
+        // generations. Per-chunk stall detection lives in `read_sse_round`.
+        .connect_timeout(std::time::Duration::from_secs(30))
         .build()
         .map_err(|e| format!("Failed to build HTTP client: {}", e))
 }
@@ -662,14 +668,33 @@ async fn read_sse_round(
     response: reqwest::Response,
     mut on_token: impl FnMut(&str),
 ) -> Result<ChatRound, String> {
+    // Abort a stream that goes silent for too long. A stalled provider — or a
+    // wedged local llama-server (e.g. KV-cache exhaustion) — would otherwise
+    // keep this future pending indefinitely, which pins the assistant turn's
+    // in-flight guard so the built-in engine never idle-unloads and its RAM is
+    // never reclaimed. Generous enough not to trip on slow first tokens or long
+    // reasoning pauses between chunks.
+    const SSE_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
     let mut stream = response.bytes_stream();
     let mut accumulator = SseChatAccumulator::default();
 
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|error| format!("Stream read failed: {}", error))?;
-        accumulator.push(&chunk, &mut on_token);
-        if accumulator.is_done() {
-            break;
+    loop {
+        match tokio::time::timeout(SSE_STALL_TIMEOUT, stream.next()).await {
+            Ok(Some(chunk)) => {
+                let chunk = chunk.map_err(|error| format!("Stream read failed: {}", error))?;
+                accumulator.push(&chunk, &mut on_token);
+                if accumulator.is_done() {
+                    break;
+                }
+            }
+            Ok(None) => break, // stream ended normally
+            Err(_) => {
+                return Err(format!(
+                    "LLM stream stalled: no data for {}s",
+                    SSE_STALL_TIMEOUT.as_secs()
+                ));
+            }
         }
     }
 

--- a/src-tauri/src/managers/local_llm.rs
+++ b/src-tauri/src/managers/local_llm.rs
@@ -609,7 +609,19 @@ impl LocalLlmManager {
             cmd.creation_flags(CREATE_NO_WINDOW);
         }
 
-        cmd.spawn()
+        let child = cmd.spawn()?;
+
+        // Tie the engine's lifetime to ours. On Windows we place it in a
+        // kill-on-close Job Object so it is terminated even if we crash, panic,
+        // or are force-killed by the OS during a memory-pressure freeze — the
+        // paths where `Drop` / exit handlers never run and an orphaned multi-GB
+        // `llama-server.exe` would otherwise survive and keep exhausting RAM.
+        // The graceful quit path additionally calls `stop()` via `RunEvent::Exit`
+        // in `lib.rs`.
+        #[cfg(windows)]
+        assign_child_to_kill_on_close_job(&child);
+
+        Ok(child)
     }
 
     /// True if something is currently accepting TCP connections on the engine
@@ -889,5 +901,71 @@ impl Drop for LlmActivityGuard {
 impl Drop for LocalLlmManager {
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+/// Assign a spawned engine child to a process-wide Job Object configured with
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. The job handle is created once and kept
+/// open for the entire process lifetime (stored as a raw `isize` in a
+/// `OnceLock`), so the only event that closes the job's last handle is THIS
+/// process terminating — at which point Windows kills every process in the job,
+/// including `llama-server.exe`.
+///
+/// This is the crash / force-kill backstop for orphaned engine processes (the
+/// root cause of the "memory keeps climbing, disk hits 100%, PC freezes"
+/// reports). The normal quit path also calls `stop()` via `RunEvent::Exit`, but
+/// that — like `Drop` — never runs when the process is killed hard (panic,
+/// crash, or the OS reaping us during a low-memory freeze).
+#[cfg(windows)]
+fn assign_child_to_kill_on_close_job(child: &Child) {
+    use std::os::windows::io::AsRawHandle;
+    use std::sync::OnceLock;
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    // Raw job handle value (stored as isize so it is Send + Sync for the
+    // OnceLock). 0 means creation failed; we then skip assignment so a failure
+    // here only disables cleanup rather than breaking engine startup.
+    static JOB: OnceLock<isize> = OnceLock::new();
+
+    let job_raw = *JOB.get_or_init(|| unsafe {
+        match CreateJobObjectW(None, PCWSTR::null()) {
+            Ok(job) => {
+                let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+                info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                if let Err(e) = SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    &info as *const _ as *const core::ffi::c_void,
+                    std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                ) {
+                    warn!("Failed to configure engine Job Object (orphan cleanup disabled): {e}");
+                }
+                job.0 as isize
+            }
+            Err(e) => {
+                warn!("Failed to create engine Job Object (orphan cleanup disabled): {e}");
+                0
+            }
+        }
+    });
+
+    if job_raw == 0 {
+        return;
+    }
+
+    let job = HANDLE(job_raw as *mut core::ffi::c_void);
+    let child_handle = HANDLE(child.as_raw_handle() as *mut core::ffi::c_void);
+    // SAFETY: `job` is a valid job handle kept open for the process lifetime and
+    // `child_handle` is the live child's process handle owned by `child`.
+    unsafe {
+        if let Err(e) = AssignProcessToJobObject(job, child_handle) {
+            warn!("Failed to assign engine process to Job Object: {e}");
+        }
     }
 }

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -330,6 +330,9 @@ pub fn create_recording_overlay(app_handle: &AppHandle) {
         "recording_overlay",
         tauri::WebviewUrl::App("src/overlay/index.html".into()),
     )
+    // Must match every other window's args (see WEBVIEW2_BROWSER_ARGS).
+    // Windows/WebView2 only; no-op on macOS/Linux.
+    .additional_browser_args(crate::WEBVIEW2_BROWSER_ARGS)
     .title("Recording")
     .resizable(false)
     .inner_size(OVERLAY_WIDTH, OVERLAY_HEIGHT)
@@ -572,11 +575,34 @@ pub fn hide_recording_overlay(app_handle: &AppHandle) {
 }
 
 pub fn emit_levels(app_handle: &AppHandle, levels: &Vec<f32>) {
-    // emit levels to main app
-    let _ = app_handle.emit("mic-level", levels);
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    // also emit to the recording overlay if it's open
-    if let Some(overlay_window) = app_handle.get_webview_window("recording_overlay") {
-        let _ = overlay_window.emit("mic-level", levels);
+    // Throttle to ~30 FPS. Ported from Handy #1279: every `emit` becomes an
+    // `evaluate_script` call in each listening WebView, and wry's
+    // `evaluate_script` has an upstream memory leak (tauri-apps/wry#1489; the
+    // WebView2/Windows equivalent is tauri#12724) that accumulates per call and
+    // is never released. The audio visualizer fired this ~94x/sec — and
+    // previously TWICE per frame via a redundant second broadcast — so over a
+    // long session WebView memory grew into the gigabytes and eventually caused
+    // swap thrashing / OOM (the "memory climbs, disk 100%, PC freezes" reports).
+    // ~30 FPS keeps the meter smooth while cutting emit volume by roughly 6x.
+    const EMIT_THROTTLE_MS: u64 = 33;
+    static LAST_EMIT_MS: AtomicU64 = AtomicU64::new(0);
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    if now.saturating_sub(LAST_EMIT_MS.load(Ordering::Relaxed)) < EMIT_THROTTLE_MS {
+        return;
     }
+    LAST_EMIT_MS.store(now, Ordering::Relaxed);
+
+    // A single global broadcast reaches every window that registered a
+    // `mic-level` listener (currently the recording overlay AND the assistant
+    // panel) and, thanks to Tauri's listener filtering, does not evaluate script
+    // in windows without one. This replaces the old pair of `.emit()` calls that
+    // delivered the event to the overlay twice per frame.
+    let _ = app_handle.emit("mic-level", levels);
 }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -46,6 +46,13 @@ pub fn cancel_current_operation(app: &AppHandle) {
         use tauri::Emitter;
         let _ = app.emit("assistant-tts-stop", ());
     }
+    // Reset the assistant panel/pill to idle. The panel renders purely from
+    // `assistant-state` events, so without this an in-progress capture
+    // (listening / transcribing / thinking / speaking) stays visually stuck
+    // after a cancel even though the recording and turn have actually stopped —
+    // the "I pressed cancel and nothing happened" bug. Safe/idempotent when the
+    // panel is hidden or already idle.
+    crate::assistant::emit_state(app, "idle");
 
     // Update tray icon and hide overlay
     change_tray_icon(app, crate::tray::TrayIconState::Idle);

--- a/src/assistant/AssistantPanel.tsx
+++ b/src/assistant/AssistantPanel.tsx
@@ -1290,6 +1290,21 @@ const AssistantPanel: React.FC = () => {
                     <Square size={11} strokeWidth={2.75} />
                   </button>
                 )}
+                {/* Cancel during voice capture: aborts the recording/
+                    transcription without sending it (the ✗ the comment above
+                    promised). Wired to the global cancel so it stops recording,
+                    STT, and any in-flight turn. */}
+                {(isListening || state === "transcribing") && (
+                  <button
+                    className="apill-btn danger apill-stop"
+                    onClick={cancelVoice}
+                    onMouseDown={stopDrag}
+                    title={t("assistant.cancel")}
+                    aria-label={t("assistant.cancel")}
+                  >
+                    <X size={11} strokeWidth={2.75} />
+                  </button>
+                )}
               </div>
             </>
           ) : (
@@ -1734,26 +1749,40 @@ const AssistantPanel: React.FC = () => {
               }
             }}
           />
-          <button
-            className="assistant-send-button"
-            onClick={isListening ? finishVoice : showStop ? stopTurn : sendText}
-            disabled={!isListening && !showStop && !input.trim()}
-            title={
-              isListening
-                ? t("assistant.finish")
-                : showStop
-                  ? t("assistant.stop")
-                  : t("assistant.send")
-            }
-          >
-            {isListening ? (
-              <Check size={16} strokeWidth={2.75} />
-            ) : showStop ? (
-              <Square size={15} strokeWidth={2.5} />
-            ) : (
-              <ArrowUp size={16} strokeWidth={2.5} />
-            )}
-          </button>
+          {(isListening || state === "transcribing") && (
+            <button
+              className="assistant-send-button"
+              onClick={cancelVoice}
+              title={t("assistant.cancel")}
+              aria-label={t("assistant.cancel")}
+            >
+              <X size={16} strokeWidth={2.75} />
+            </button>
+          )}
+          {state !== "transcribing" && (
+            <button
+              className="assistant-send-button"
+              onClick={
+                isListening ? finishVoice : showStop ? stopTurn : sendText
+              }
+              disabled={!isListening && !showStop && !input.trim()}
+              title={
+                isListening
+                  ? t("assistant.finish")
+                  : showStop
+                    ? t("assistant.stop")
+                    : t("assistant.send")
+              }
+            >
+              {isListening ? (
+                <Check size={16} strokeWidth={2.75} />
+              ) : showStop ? (
+                <Square size={15} strokeWidth={2.5} />
+              ) : (
+                <ArrowUp size={16} strokeWidth={2.5} />
+              )}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/assistant/useKokoroTts.ts
+++ b/src/assistant/useKokoroTts.ts
@@ -40,6 +40,30 @@ function hasWebGpu(): boolean {
   return typeof navigator !== "undefined" && "gpu" in navigator;
 }
 
+/** Best-effort release of the kokoro-js model's ONNX session + WebGPU buffers.
+ *  kokoro-js wraps a transformers.js model whose `.dispose()` frees the
+ *  onnxruntime InferenceSession(s) (hundreds of MB, plus GPU buffers). The
+ *  exact shape isn't in our minimal type, so probe the known locations and
+ *  swallow errors — nulling the ref then lets GC reclaim the rest. Without
+ *  this, changing precision / disabling TTS / closing the panel orphaned a
+ *  full model in the WebView, a major contributor to the memory growth. */
+async function disposeModel(model: KokoroModel | null): Promise<void> {
+  if (!model) return;
+  try {
+    const anyModel = model as unknown as {
+      dispose?: () => unknown;
+      model?: { dispose?: () => unknown };
+    };
+    if (typeof anyModel.dispose === "function") {
+      await anyModel.dispose();
+    } else if (typeof anyModel.model?.dispose === "function") {
+      await anyModel.model.dispose();
+    }
+  } catch {
+    // best-effort; the GC reclaims the rest once the ref is dropped
+  }
+}
+
 /**
  * Local TTS via kokoro-js. Prefers WebGPU (fp32, ~10x faster than wasm on a
  * discrete GPU) with wasm/q8 fallback. Sentences are synthesized as a stream
@@ -148,6 +172,11 @@ export function useKokoroTts(
     } else if (!enabled) {
       setError(null);
       setStatus((s) => (s === "speaking" || s === "ready" ? "off" : s));
+      // Turned off: free the model so its ONNX/WebGPU memory isn't pinned for
+      // the WebView's lifetime. It reloads on demand if re-enabled.
+      void disposeModel(modelRef.current);
+      modelRef.current = null;
+      loadingRef.current = null;
     }
   }, [enabled, preload, ensureLoaded]);
 
@@ -157,6 +186,17 @@ export function useKokoroTts(
     const el = playingRef.current;
     if (el) {
       el.pause();
+      // Revoke the in-flight clip's object URL. onended/onerror (which normally
+      // revoke) don't fire on pause(), so without this every interrupted or
+      // restarted spoken reply leaked a blob URL.
+      if (el.src) {
+        try {
+          URL.revokeObjectURL(el.src);
+        } catch {
+          // ignore
+        }
+        el.removeAttribute("src");
+      }
       playingRef.current = null;
     }
     setError(null);
@@ -169,6 +209,9 @@ export function useKokoroTts(
     if (dtypeRef.current === dtype) return;
     dtypeRef.current = dtype;
     stop();
+    // Release the old-precision session before dropping the ref, or its
+    // ONNX/WebGPU memory leaks on every precision change.
+    void disposeModel(modelRef.current);
     modelRef.current = null;
     loadingRef.current = null;
     setStatus("off");
@@ -176,6 +219,31 @@ export function useKokoroTts(
       ensureLoaded().catch(() => {});
     }
   }, [dtype, enabled, preload, ensureLoaded, stop]);
+
+  // Release the model + audio when the hook unmounts (e.g. the panel window is
+  // torn down). The ONNX session and its WebGPU buffers are hundreds of MB;
+  // without this they leak for the lifetime of the WebView.
+  useEffect(() => {
+    return () => {
+      generationRef.current += 1;
+      queueRef.current = [];
+      const el = playingRef.current;
+      if (el) {
+        el.pause();
+        if (el.src) {
+          try {
+            URL.revokeObjectURL(el.src);
+          } catch {
+            // ignore
+          }
+        }
+        playingRef.current = null;
+      }
+      void disposeModel(modelRef.current);
+      modelRef.current = null;
+      loadingRef.current = null;
+    };
+  }, []);
 
   /** Play queued blobs back-to-back; exits when queue drains. */
   const pump = useCallback((generation: number) => {

--- a/src/components/settings/assistant/AssistantSettings.tsx
+++ b/src/components/settings/assistant/AssistantSettings.tsx
@@ -423,9 +423,50 @@ export const AssistantSettings: React.FC<AssistantSettingsProps> = ({
   const kokoroReadyKey = `speakoflow.kokoro.ready.${ttsDtype}`;
   const [kokoroPrepared, setKokoroPrepared] = useState(false);
 
+  // Reflect the ACTUAL browser cache, not just a local flag. kokoro-js
+  // (transformers.js) caches model weights in the "transformers-cache" Cache
+  // Storage; if this precision's weights are already present, the model is
+  // ready and we must NOT prompt a re-download. This fixes "have to click
+  // Download every time you switch": the old flag was keyed per-precision and
+  // only set from this page, so it desynced from reality (e.g. after the live
+  // panel had already downloaded the model). Falls back to the local flag if
+  // the Cache API is unavailable, so there's no regression.
   useEffect(() => {
-    setKokoroPrepared(window.localStorage.getItem(kokoroReadyKey) === "true");
-  }, [kokoroReadyKey]);
+    let cancelled = false;
+    const dtypeSuffix: Record<string, string> = {
+      fp32: "",
+      fp16: "_fp16",
+      q8: "_quantized",
+      int8: "_int8",
+      uint8: "_uint8",
+      q4: "_q4",
+      q4f16: "_q4f16",
+      bnb4: "_bnb4",
+    };
+    const refresh = async () => {
+      let cached = false;
+      try {
+        if (typeof caches !== "undefined") {
+          const cache = await caches.open("transformers-cache");
+          const urls = (await cache.keys())
+            .map((r) => r.url)
+            .filter((u) => u.includes("Kokoro-82M"));
+          const file = `model${dtypeSuffix[ttsDtype] ?? ""}.onnx`;
+          cached =
+            urls.some((u) => u.includes(file)) ||
+            urls.some((u) => u.endsWith(".onnx"));
+        }
+      } catch {
+        cached = false;
+      }
+      const flagged = window.localStorage.getItem(kokoroReadyKey) === "true";
+      if (!cancelled) setKokoroPrepared(cached || flagged);
+    };
+    void refresh();
+    return () => {
+      cancelled = true;
+    };
+  }, [kokoroReadyKey, ttsDtype]);
 
   const rememberKokoroReady = () => {
     window.localStorage.setItem(kokoroReadyKey, "true");

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1471,6 +1471,7 @@
     "inputPlaceholderScreen": "Ask about your screen…",
     "send": "Send",
     "stop": "Stop",
+    "cancel": "Cancel",
     "finish": "Finish & send",
     "clear": "Clear conversation",
     "hide": "Hide panel",


### PR DESCRIPTION
## Summary

Fixes severe stability + UX issues in the assistant/TTS stack: memory growing until the disk thrashed and the machine froze, the panel being unstoppable mid-turn, robotic TTS, and TTS models re-downloading on every switch.

## Changes

**Memory / crash (the disk-100%-then-freeze bug)**
- Kill the orphaned `llama-server` sidecar: a Windows kill-on-close Job Object + a `RunEvent::Exit` cleanup (it was never killed on quit/crash and accumulated across launches).
- Curb the upstream `wry` `evaluate_script` WebView leak (Handy #1279): throttle `mic-level` IPC to ~30 FPS and coalesce `assistant-token` emits.
- Add an LLM connect timeout + a 120s SSE stall timeout so a hung stream cannot pin the engine resident (also restores idle-unload).
- Release the Kokoro ONNX/WebGPU session + revoke audio blob URLs (WebView leak).

**Cancellation**
- Make the built-in model-load phase cancellable.
- Wire a real cancel (Esc / the pill stop) during listening and transcribing.

**TTS quality + downloads**
- Enable WebGPU in WebView2 (`--enable-unsafe-webgpu`) so Kokoro runs fp32 on the GPU instead of the robotic wasm/q8 fallback (Windows; safe wasm fallback elsewhere), plus `--autoplay-policy=no-user-gesture-required` so spoken replies are not silently blocked.
- Detect Kokoro download state from the browser cache so switching precision no longer forces a re-download.

**Docs**
- `docs/future-work.md`: the backend-TTS migration plan + deferred items.

## Testing
- `cargo check` passes (backend); `bun run build` passes (tsc + vite); `bun run tauri dev` launches locally.
- WebGPU path needs on-device confirmation (console: `[Kokoro TTS] loaded on webgpu (fp32)` vs the wasm fallback).

## AI assistance
Implemented with the help of an AI coding assistant (Kiro), with human review.

## Human-written description
TODO(@AbhishekBarali): add your own summary/notes before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated cancel controls for voice recording and transcription.
  * Improved assistant streaming responsiveness and preserved partial responses when cancelled.
  * Added more reliable detection of downloaded Kokoro voice models.
* **Bug Fixes**
  * Improved cleanup of voice model memory and temporary audio resources.
  * Local AI processes now close more reliably when the app exits or crashes.
  * Network connections and stalled assistant responses now fail gracefully instead of hanging indefinitely.
  * Cancelled operations now consistently return the assistant interface to an idle state.
* **Documentation**
  * Added a backlog of deferred product improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->