### PR TITLE
Release v1.0.1: fixes, LLM engine progress, quit-on-close

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,40 @@ SpeakoFlow handles this automatically: when it detects GNOME on Wayland it runs 
 - Force native Wayland anyway (the overlay may not stay on top): launch with `SPEAKOFLOW_ALLOW_WAYLAND=1`.
 - If the overlay misbehaves under a layer-shell compositor, disable layer shell with `SPEAKOFLOW_NO_GTK_LAYER_SHELL=1`.
 
+### Linux: hotkeys do nothing and the logs repeat "Permission denied"
+
+If dictation and the assistant hotkeys don't respond on Linux and you see the log
+repeating `rdev grab error: ... PermissionDenied` (errno 13), the app can't read
+your input devices. This affects the **handy-keys** keyboard engine, which reads
+`/dev/input/event*` and needs your user to be in the `input` group.
+
+Two ways to fix it:
+
+- **Grant access** — add your user to the `input` group, then log out and back in:
+
+  ```bash
+  sudo usermod -aG input $USER
+  ```
+
+- **Or switch engines** — set the keyboard engine to **Tauri** in Settings, which
+  uses the compositor's global-shortcut API and needs no special permissions.
+  (Tauri is already the default engine on Linux, so this only affects you if you
+  switched to handy-keys.)
+
+### Linux: the app crashes when you pinch-to-zoom on a touchpad
+
+On some Linux setups a trackpad pinch-to-zoom gesture crashes the window, with
+`Received invalid message: 'DrawingArea_CommitTransientZoom'` in the logs. This
+is a bug in **WebKitGTK** (the Linux web engine Tauri/wry uses), not in
+SpeakoFlow itself, and it affects many WebKitGTK-based apps. It is tracked
+upstream in [tauri#13115](https://github.com/tauri-apps/tauri/issues/13115) and
+[wry#544](https://github.com/tauri-apps/wry/issues/544).
+
+Until there's an upstream fix, avoid the pinch-to-zoom gesture inside the app
+window. Updating your system's WebKitGTK packages (`webkit2gtk-4.1`) to the
+latest version can also help, since newer releases handle the gesture more
+gracefully.
+
 ## Roadmap
 
 - Code signing for Windows and macOS

--- a/docs/PROVIDER_AUDIT.md
+++ b/docs/PROVIDER_AUDIT.md
@@ -17,6 +17,76 @@ Legend for **Matches?**: ✅ matches current docs · ⚠️ works but has a cave
 
 ---
 
+## Update — 2026-07-21 (live re-audit, model-name-format focus)
+
+Re-verified **every** provider against current live docs (keyless), triggered by
+a real-world Gemini failure. This pass specifically checked the dimension the
+first audit under-weighted: **does each provider's `/models` list return IDs the
+chat endpoint actually accepts?** — the mismatch that broke Gemini.
+
+**Verdict: exactly one real bug across the whole surface — Gemini — now fixed.**
+Every other provider's base URL, auth, and endpoint paths are correct, and their
+`/models` IDs are chat-usable (either bare, or a vendor/account prefix used
+_consistently_ by both the list and the chat endpoint, so no normalization is
+needed).
+
+### LLM / model providers
+
+| Provider              | Base URL                                          | Model-name / `/models` match                                                                             | Status                                               |
+| --------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| OpenAI                | api.openai.com/v1                                 | bare, list == chat                                                                                       | ✅                                                   |
+| OpenRouter            | openrouter.ai/api/v1                              | `vendor/model`, consistent                                                                               | ✅                                                   |
+| Anthropic             | api.anthropic.com/v1                              | bare `claude-*`, OpenAI-compat layer, `x-api-key`                                                        | ✅                                                   |
+| Groq                  | api.groq.com/openai/v1                            | bare, consistent                                                                                         | ✅                                                   |
+| Cerebras              | api.cerebras.ai/v1                                | bare, consistent                                                                                         | ✅                                                   |
+| Z.AI                  | api.z.ai/api/paas/v4                              | bare `glm-*`, consistent                                                                                 | ✅                                                   |
+| **Google Gemini**     | generativelanguage.googleapis.com/v1beta/openai   | `/models` returns `models/…`; chat wants bare `gemini-*`                                                 | ❌→✅ **fixed** (strip leading `models/`)            |
+| xAI (Grok)            | api.x.ai/v1                                        | bare `grok-*`, consistent (`/v1/models` exists)                                                          | ✅                                                   |
+| DeepSeek              | api.deepseek.com (`/v1` alias ok)                 | bare, consistent                                                                                         | ✅ (see note)                                        |
+| Mistral               | api.mistral.ai/v1                                 | bare `*-latest`, consistent (`/v1/models`)                                                               | ✅                                                   |
+| Moonshot (Kimi)       | api.moonshot.ai/v1                                | bare `kimi-*`, consistent (`/v1/models`)                                                                 | ✅                                                   |
+| Together AI           | api.together.xyz/v1                               | `vendor/Model`, consistent                                                                               | ✅                                                   |
+| Fireworks AI          | api.fireworks.ai/inference/v1                     | `accounts/fireworks/models/…`, consistent                                                                | ✅                                                   |
+| Perplexity            | api.perplexity.ai                                 | bare `sonar*`; no `/models` list (so `models_endpoint: None` is correct); `/chat/completions` is a documented alias of `/v1/sonar` | ✅                                                   |
+| Azure OpenAI          | \*.openai.azure.com/openai/v1                      | deployment name; hosts normalized to `/openai/v1`; `Bearer` + `api-key`                                  | ✅                                                   |
+| **AWS Bedrock (Mantle)** | bedrock-mantle.{region}.api.aws/v1             | `provider.model` (e.g. `openai.gpt-oss-120b`); `Bearer` (Bedrock API key / AWS bearer token)             | ✅ **confirmed real** (corrects earlier "unverified") |
+
+**Only code change from this re-audit:** the Gemini `models/` strip in
+`llm_client.rs` (`normalize_model_name`, applied in `build_chat_completion_request`
+and `fetch_models`), with regression tests. Because the client and provider table
+are shared, this fixes both the Assistant and the dictation AI-cleanup path at
+once. No `web_search.rs` / `tts.rs` changes were needed.
+
+**AWS Bedrock (Mantle) — corrected:** confirmed real against the official AWS
+docs. Amazon Bedrock's "Project Mantle" exposes an OpenAI-compatible Chat
+Completions API at `https://bedrock-mantle.{region}.api.aws/v1/chat/completions`
+with `Authorization: Bearer` (a Bedrock API key or an AWS bearer token). The
+configured base URL and auth are correct; this supersedes the old "needs a live
+key / unverified" note below.
+
+**Note (DeepSeek):** `deepseek-chat` / `deepseek-reasoner` are documented as
+deprecating on **2026-07-24**, replaced by `deepseek-v4-pro` / `deepseek-v4-flash`.
+This is a catalog change only — the free-text model field and the live `/models`
+picker surface the new names, so no code change is required.
+
+### Web search & TTS
+
+Re-confirmed unchanged from the 2026-07-01 audit and still matching current docs:
+Serper (`google.serper.dev/search`, `X-API-KEY`), Brave
+(`api.search.brave.com/res/v1/web/search`, `X-Subscription-Token`; free tier still
+removed), Tavily (`POST api.tavily.com/search`, `Bearer`; now also offers a keyless
+tier), Exa (`api.exa.ai/search`, `x-api-key`), SerpAPI (`serpapi.com/search.json`,
+`api_key`). TTS: OpenAI-compatible `{base}/audio/speech` (`Bearer`), ElevenLabs
+`/v1/text-to-speech/{voice}` (`xi-api-key`), Azure Speech `cognitiveservices/v1`
+with voices at `/tts/cognitiveservices/voices/list` (custom domain) or
+`/cognitiveservices/voices/list` (regional) (`Ocp-Apim-Subscription-Key`), Kokoro
+(local, in-webview).
+
+> The historical tables below (2026-07-01) are kept for reference; where they
+> disagree with this section, this section wins.
+
+---
+
 ## 1. Assistant LLM providers
 
 All LLM providers use one code path: `POST {base_url}/chat/completions` with an
@@ -161,8 +231,10 @@ All other providers matched their current docs and needed **no code change**.
 - **Brave free tier removed**: Brave Search API no longer offers a free plan.
   Not a code issue, but worth surfacing in the settings hint so users aren't
   surprised.
-- **AWS Bedrock (Mantle)**: OpenAI-compat gateway; shape looks right but
-  unverified against AWS docs. Needs a live key to confirm.
+- **AWS Bedrock (Mantle)**: **confirmed real** in the 2026-07-21 re-audit (see the
+  update section at the top). Amazon Bedrock's "Project Mantle" OpenAI-compatible
+  Chat Completions endpoint (`bedrock-mantle.{region}.api.aws/v1`, `Bearer`) matches
+  the configured base URL and auth. No longer an open question.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "speakoflow",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6653,7 +6653,7 @@ dependencies = [
 
 [[package]]
 name = "speakoflow"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speakoflow"
-version = "1.0.0"
+version = "1.0.1"
 description = "SpeakoFlow"
 authors = ["AbhishekBarali"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -580,6 +580,7 @@ pub fn run(cli_args: CliArgs) {
             shortcut::change_keyboard_implementation_setting,
             shortcut::get_keyboard_implementation,
             shortcut::change_show_tray_icon_setting,
+            shortcut::change_close_behavior_setting,
             shortcut::change_whisper_accelerator_setting,
             shortcut::change_ort_accelerator_setting,
             shortcut::change_whisper_gpu_device,
@@ -977,8 +978,24 @@ pub fn run(cli_args: CliArgs) {
         })
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::CloseRequested { api, .. } => {
-                // Remember the size before hiding, so it reopens as left.
+                // Remember the size before hiding/quitting, so it reopens as left.
                 save_main_window_size(window);
+
+                // Issue #6: honor the user's close preference. The default stays
+                // "minimize to tray" (handled below); only fully quit when the
+                // user explicitly opted in.
+                if matches!(
+                    get_settings(&window.app_handle()).close_behavior,
+                    crate::settings::CloseBehavior::Quit
+                ) {
+                    // Reuse the same clean exit path as the tray "Quit" item:
+                    // `app.exit(0)` fires `RunEvent::Exit`, which tears down the
+                    // built-in LLM sidecar (the fix from issue #2). We must not
+                    // prevent the close in this branch.
+                    window.app_handle().exit(0);
+                    return;
+                }
+
                 api.prevent_close();
                 let _res = window.hide();
 

--- a/src-tauri/src/llm_client.rs
+++ b/src-tauri/src/llm_client.rs
@@ -103,7 +103,7 @@ fn build_chat_completion_request(
     });
 
     ChatCompletionRequest {
-        model: model.to_string(),
+        model: normalize_model_name(provider, model),
         messages,
         response_format,
         reasoning_effort: options.reasoning_effort,
@@ -252,6 +252,36 @@ fn effective_base_url(provider: &PostProcessProvider) -> String {
         return format!("https://{}/openai/v1", host);
     }
     raw.to_string()
+}
+
+/// True when a provider targets Google Gemini's OpenAI-compatible surface.
+fn is_gemini_provider(provider: &PostProcessProvider) -> bool {
+    provider
+        .base_url
+        .contains("generativelanguage.googleapis.com")
+}
+
+/// Normalize a model id for provider-specific quirks before it is sent.
+///
+/// Google Gemini's OpenAI-compatible `/models` endpoint returns ids with a
+/// `models/` prefix (e.g. `models/gemini-2.5-flash`), mirroring the native REST
+/// resource names — but its `/chat/completions` endpoint expects the BARE id
+/// (`gemini-2.5-flash`), exactly like every example in Google's OpenAI-compat
+/// docs. A user who picks a model from the "Load models" list therefore ends up
+/// with a `models/…` value the chat endpoint rejects (surfacing as "couldn't
+/// get an answer"), while OpenRouter and the other providers — which return
+/// bare ids — just work. Strip the prefix for Gemini so it behaves like the
+/// rest. No-op for every other provider and for values that are already bare.
+///
+/// Applies to both the Assistant and the dictation AI-cleanup path, since both
+/// share this client and the provider table.
+fn normalize_model_name(provider: &PostProcessProvider, model: &str) -> String {
+    if is_gemini_provider(provider) {
+        if let Some(bare) = model.strip_prefix("models/") {
+            return bare.to_string();
+        }
+    }
+    model.to_string()
 }
 
 /// Extract the plain-text content of a chat message whose `content` may be a
@@ -887,6 +917,14 @@ pub async fn fetch_models(
         }
     }
 
+    // Present bare model ids for Gemini (its `/models` lists `models/…` names
+    // that its chat endpoint rejects), so both the picker and the value that
+    // gets stored are the ones chat actually accepts. No-op elsewhere.
+    let models = models
+        .into_iter()
+        .map(|model| normalize_model_name(provider, &model))
+        .collect();
+
     Ok(models)
 }
 
@@ -964,6 +1002,63 @@ mod tests {
             effective_base_url(&provider("local", "http://localhost:11434/v1")),
             "http://localhost:11434/v1"
         );
+    }
+
+    #[test]
+    fn gemini_model_name_strips_leading_models_prefix() {
+        let gemini = provider(
+            "gemini",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+        );
+        // The `models/…` id returned by Gemini's /models list is reduced to the
+        // bare id its chat endpoint expects.
+        assert_eq!(
+            normalize_model_name(&gemini, "models/gemini-2.5-flash"),
+            "gemini-2.5-flash"
+        );
+        assert_eq!(
+            normalize_model_name(&gemini, "models/gemini-3.1-flash-lite"),
+            "gemini-3.1-flash-lite"
+        );
+        // An already-bare id is untouched.
+        assert_eq!(
+            normalize_model_name(&gemini, "gemini-2.5-flash"),
+            "gemini-2.5-flash"
+        );
+        // Only a single leading prefix is stripped; interior text is preserved.
+        assert_eq!(
+            normalize_model_name(&gemini, "models/tuned-models/my-model"),
+            "tuned-models/my-model"
+        );
+    }
+
+    #[test]
+    fn non_gemini_model_names_are_untouched() {
+        // OpenRouter uses `vendor/model` ids that must NOT be altered.
+        let openrouter = provider("openrouter", "https://openrouter.ai/api/v1");
+        assert_eq!(
+            normalize_model_name(&openrouter, "google/gemini-2.5-flash"),
+            "google/gemini-2.5-flash"
+        );
+        // A hypothetical `models/`-prefixed id on a non-Gemini host is left as-is.
+        let openai = provider("openai", "https://api.openai.com/v1");
+        assert_eq!(normalize_model_name(&openai, "models/foo"), "models/foo");
+    }
+
+    #[test]
+    fn request_builder_normalizes_gemini_model() {
+        let gemini = provider(
+            "gemini",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+        );
+        let request = build_chat_completion_request(
+            &gemini,
+            "models/gemini-2.5-flash",
+            vec![serde_json::json!({"role": "user", "content": "hi"})],
+            ChatRequestOptions::default(),
+        );
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["model"], "gemini-2.5-flash");
     }
 
     #[test]

--- a/src-tauri/src/managers/local_llm.rs
+++ b/src-tauri/src/managers/local_llm.rs
@@ -34,6 +34,15 @@ use tauri::{AppHandle, Emitter, Manager};
 /// Ollama's default (11434) so a user's existing Ollama install is untouched.
 const ENGINE_PORT: u16 = 11435;
 
+/// Pinned llama.cpp release used as a fallback when the GitHub "latest" API is
+/// unreachable or rate-limited. Its assets are fetched directly from the
+/// release-download host, which — unlike `api.github.com` — is NOT subject to
+/// the 60-requests/hour unauthenticated rate limit that shared campus/office
+/// NAT IPs routinely exhaust (the root cause of "No assets in latest llama.cpp
+/// release"). Overridable at runtime via the `HANDY_LLAMA_RELEASE_TAG` env var
+/// so a newer/older build can be pinned without a rebuild.
+const PINNED_ENGINE_TAG: &str = "b10075";
+
 /// Default context window if the user hasn't chosen one. 8192 leaves room for
 /// the system prompt, chat history, a screenshot (vision models can spend
 /// ~1k+ tokens on one image), and the reply — a 4096 window overflows on a
@@ -199,9 +208,17 @@ impl LocalLlmManager {
         None
     }
 
-    /// Ensure an engine binary is available, downloading the official
-    /// llama.cpp release for this platform into `<models>/engine/` if none is
-    /// found anywhere. Returns the path to the binary.
+    /// Ensure an engine binary is available, downloading a llama.cpp release
+    /// for this platform into `<models>/engine/` if none is found anywhere.
+    /// Returns the path to the binary.
+    ///
+    /// Robustness: tries the current GitHub "latest" release first, then falls
+    /// back to a PINNED release whose download URLs are constructed directly.
+    /// The pinned URLs hit the release-download host rather than the
+    /// rate-limited `api.github.com`, so a throttled or offline GitHub API — the
+    /// usual cause of "No assets in latest llama.cpp release" on shared
+    /// school/office networks — no longer blocks setup. On total failure it
+    /// returns a clear, actionable message instead of a cryptic API error.
     async fn ensure_engine_installed(&self) -> Result<PathBuf, String> {
         if let Some(path) = self.resolve_engine_binary() {
             return Ok(path);
@@ -216,22 +233,97 @@ impl LocalLlmManager {
             .app_handle
             .emit("local-llm-engine-status", "downloading");
 
-        let url = self.resolve_engine_asset_url().await?;
-        let zip_path = engine_dir.join("llama-engine.zip");
-        self.download_to_file(&url, &zip_path).await?;
+        // Ordered candidate archive URLs: the live "latest" asset first (best
+        // match for this platform, when the API is reachable), then the pinned
+        // fallback URLs. Trying the pinned build means a rate-limited/offline
+        // GitHub API can't stop the built-in engine from installing.
+        let mut candidates: Vec<String> = Vec::new();
+        match self.resolve_latest_asset_url().await {
+            Ok(url) => candidates.push(url),
+            Err(e) => warn!(
+                "Could not resolve the latest llama.cpp release ({}); falling back \
+                 to the pinned build {}",
+                e, PINNED_ENGINE_TAG
+            ),
+        }
+        for url in self.pinned_asset_urls() {
+            if !candidates.contains(&url) {
+                candidates.push(url);
+            }
+        }
+
+        if candidates.is_empty() {
+            let _ = self.app_handle.emit("local-llm-engine-status", "error");
+            return Err(
+                "No compatible llama.cpp prebuilt binary is available for this platform."
+                    .to_string(),
+            );
+        }
+
+        let mut last_error = String::from("unknown error");
+        for url in candidates {
+            match self.download_and_extract_engine(&url, &engine_dir).await {
+                Ok(()) => {
+                    if let Some(resolved) = self.resolve_engine_binary() {
+                        let _ = self.app_handle.emit("local-llm-engine-status", "ready");
+                        info!("Built-in LLM engine installed at {}", resolved.display());
+                        return Ok(resolved);
+                    }
+                    last_error = "engine archive downloaded but no llama-server binary was inside"
+                        .to_string();
+                    warn!("{} (source: {})", last_error, url);
+                }
+                Err(e) => {
+                    warn!("Engine download attempt failed ({}): {}", url, e);
+                    last_error = e;
+                }
+            }
+        }
+
+        let _ = self.app_handle.emit("local-llm-engine-status", "error");
+        Err(format!(
+            "Couldn't set up the built-in engine (llama.cpp). This is usually a network \
+             problem or GitHub rate-limiting (common on shared school/office Wi-Fi). Try \
+             again in a few minutes, switch networks, or pick a cloud or local \
+             (Ollama / LM Studio) provider in Settings → Assistant. Last error: {}",
+            last_error
+        ))
+    }
+
+    /// Download one engine archive `url` into `engine_dir` and extract it.
+    /// The extractor is chosen from the URL's extension: Windows assets are
+    /// `.zip`, macOS/Linux assets are `.tar.gz`.
+    async fn download_and_extract_engine(
+        &self,
+        url: &str,
+        engine_dir: &Path,
+    ) -> Result<(), String> {
+        let lower = url.to_ascii_lowercase();
+        let is_tar_gz = lower.ends_with(".tar.gz") || lower.ends_with(".tgz");
+        let archive_name = if is_tar_gz {
+            "llama-engine.tar.gz"
+        } else {
+            "llama-engine.zip"
+        };
+        let archive_path = engine_dir.join(archive_name);
+
+        let _ = self
+            .app_handle
+            .emit("local-llm-engine-status", "downloading");
+        self.download_to_file(url, &archive_path).await?;
 
         let _ = self
             .app_handle
             .emit("local-llm-engine-status", "extracting");
-        Self::extract_zip(&zip_path, &engine_dir)?;
-        let _ = std::fs::remove_file(&zip_path);
-
-        let resolved = self.resolve_engine_binary().ok_or_else(|| {
-            "Engine downloaded but the llama-server binary was not found in the archive".to_string()
-        })?;
-        let _ = self.app_handle.emit("local-llm-engine-status", "ready");
-        info!("Built-in LLM engine installed at {}", resolved.display());
-        Ok(resolved)
+        let result = if is_tar_gz {
+            Self::extract_tar_gz(&archive_path, engine_dir)
+        } else {
+            Self::extract_zip(&archive_path, engine_dir)
+        };
+        // Always clean up the archive, success or failure, so a partial/corrupt
+        // download can't wedge the next attempt.
+        let _ = std::fs::remove_file(&archive_path);
+        result
     }
 
     /// Token sets (in priority order) used to pick the right release asset for
@@ -254,16 +346,35 @@ impl LocalLlmManager {
         }
     }
 
-    /// Query the latest llama.cpp GitHub release and return the download URL of
-    /// the best-matching prebuilt binary for this platform.
-    async fn resolve_engine_asset_url(&self) -> Result<String, String> {
+    /// Query the GitHub "latest" release for the best-matching prebuilt binary
+    /// URL for this platform.
+    ///
+    /// Crucially, this checks the HTTP status before parsing: an unauthenticated
+    /// request that is rate-limited returns HTTP 403/429 with a JSON body that
+    /// has no `assets` field, which the previous code misreported as "No assets
+    /// in latest llama.cpp release". Returning a real error here lets the caller
+    /// fall back to the pinned build instead of dead-ending.
+    async fn resolve_latest_asset_url(&self) -> Result<String, String> {
         let client = reqwest::Client::new();
-        let release: serde_json::Value = client
+        let response = client
             .get("https://api.github.com/repos/ggml-org/llama.cpp/releases/latest")
             .header("User-Agent", "speakoflow")
+            .header("Accept", "application/vnd.github+json")
             .send()
             .await
-            .map_err(|e| format!("Failed to query llama.cpp releases: {}", e))?
+            .map_err(|e| format!("Failed to query llama.cpp releases: {}", e))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let hint = if status.as_u16() == 403 || status.as_u16() == 429 {
+                " (GitHub API rate limit — common on shared networks)"
+            } else {
+                ""
+            };
+            return Err(format!("GitHub API returned HTTP {}{}", status, hint));
+        }
+
+        let release: serde_json::Value = response
             .json()
             .await
             .map_err(|e| format!("Failed to parse llama.cpp release info: {}", e))?;
@@ -271,7 +382,7 @@ impl LocalLlmManager {
         let assets = release
             .get("assets")
             .and_then(|a| a.as_array())
-            .ok_or_else(|| "No assets in latest llama.cpp release".to_string())?;
+            .ok_or_else(|| "latest release listing contained no assets".to_string())?;
 
         for tokens in Self::engine_asset_preferences() {
             for asset in assets {
@@ -283,7 +394,71 @@ impl LocalLlmManager {
                 }
             }
         }
-        Err("No compatible llama.cpp prebuilt binary found for this platform".to_string())
+        Err("no compatible prebuilt asset in the latest release".to_string())
+    }
+
+    /// Directly-constructed download URLs for the pinned llama.cpp release, in
+    /// priority order for this OS/arch. These target the release-download host
+    /// (not the rate-limited `api.github.com`), so they succeed even when the
+    /// "latest" lookup is throttled or the machine is behind a busy shared IP.
+    /// The tag is overridable via `HANDY_LLAMA_RELEASE_TAG`.
+    fn pinned_asset_urls(&self) -> Vec<String> {
+        let tag = std::env::var("HANDY_LLAMA_RELEASE_TAG")
+            .ok()
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .unwrap_or_else(|| PINNED_ENGINE_TAG.to_string());
+        Self::pinned_asset_urls_for(&tag)
+    }
+
+    /// Build the pinned release-download URLs for `tag`. Split out from
+    /// `pinned_asset_urls` so it is unit-testable without a Tauri `AppHandle`.
+    fn pinned_asset_urls_for(tag: &str) -> Vec<String> {
+        Self::pinned_asset_names(tag)
+            .into_iter()
+            .map(|name| {
+                format!(
+                    "https://github.com/ggml-org/llama.cpp/releases/download/{}/{}",
+                    tag, name
+                )
+            })
+            .collect()
+    }
+
+    /// Prebuilt archive filenames for the pinned release, in priority order for
+    /// this OS/arch, following llama.cpp's `llama-<tag>-bin-<platform>.<ext>`
+    /// convention. Windows ships `.zip`; macOS/Linux ship `.tar.gz`. Vulkan
+    /// builds are preferred (matching the app's Whisper backend) with a CPU
+    /// build as the always-works fallback.
+    fn pinned_asset_names(tag: &str) -> Vec<String> {
+        if cfg!(target_os = "windows") {
+            if cfg!(target_arch = "aarch64") {
+                vec![format!("llama-{tag}-bin-win-cpu-arm64.zip")]
+            } else {
+                vec![
+                    format!("llama-{tag}-bin-win-vulkan-x64.zip"),
+                    format!("llama-{tag}-bin-win-cpu-x64.zip"),
+                ]
+            }
+        } else if cfg!(target_os = "macos") {
+            if cfg!(target_arch = "aarch64") {
+                vec![format!("llama-{tag}-bin-macos-arm64.tar.gz")]
+            } else {
+                vec![format!("llama-{tag}-bin-macos-x64.tar.gz")]
+            }
+        } else if cfg!(target_arch = "aarch64") {
+            // Linux arm64
+            vec![
+                format!("llama-{tag}-bin-ubuntu-vulkan-arm64.tar.gz"),
+                format!("llama-{tag}-bin-ubuntu-arm64.tar.gz"),
+            ]
+        } else {
+            // Linux x64
+            vec![
+                format!("llama-{tag}-bin-ubuntu-vulkan-x64.tar.gz"),
+                format!("llama-{tag}-bin-ubuntu-x64.tar.gz"),
+            ]
+        }
     }
 
     /// Stream a URL to a file, emitting coarse progress events.
@@ -369,6 +544,21 @@ impl LocalLlmManager {
                 }
             }
         }
+        Ok(())
+    }
+
+    /// Extract a `.tar.gz` archive into `dest`. The `tar` crate restores the
+    /// executable bit stored in the archive, so `llama-server` stays runnable.
+    /// Used for the macOS/Linux release assets (which ship as `.tar.gz`);
+    /// Windows assets are `.zip` and go through `extract_zip`.
+    fn extract_tar_gz(archive_path: &Path, dest: &Path) -> Result<(), String> {
+        let file = std::fs::File::open(archive_path)
+            .map_err(|e| format!("Failed to open archive: {}", e))?;
+        let decoder = flate2::read::GzDecoder::new(file);
+        let mut archive = tar::Archive::new(decoder);
+        archive
+            .unpack(dest)
+            .map_err(|e| format!("Failed to extract archive: {}", e))?;
         Ok(())
     }
 
@@ -966,6 +1156,58 @@ fn assign_child_to_kill_on_close_job(child: &Child) {
     unsafe {
         if let Err(e) = AssignProcessToJobObject(job, child_handle) {
             warn!("Failed to assign engine process to Job Object: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Asset naming was verified live against the llama.cpp b10075 release:
+    // Windows ships `llama-<tag>-bin-win-*-x64.zip`, macOS/Linux ship
+    // `llama-<tag>-bin-*.tar.gz`. These guard against silent drift in the
+    // pinned-fallback filenames (which are constructed, not discovered).
+    #[test]
+    fn pinned_asset_names_match_platform_convention() {
+        let names = LocalLlmManager::pinned_asset_names("b10075");
+        assert!(
+            !names.is_empty(),
+            "the current platform must have at least one pinned asset"
+        );
+        for name in &names {
+            assert!(
+                name.starts_with("llama-b10075-bin-"),
+                "unexpected asset name: {name}"
+            );
+            if cfg!(target_os = "windows") {
+                assert!(name.ends_with(".zip"), "Windows assets are .zip: {name}");
+            } else {
+                assert!(
+                    name.ends_with(".tar.gz"),
+                    "macOS/Linux assets are .tar.gz: {name}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pinned_asset_urls_target_release_download_host_not_api() {
+        let urls = LocalLlmManager::pinned_asset_urls_for("b10075");
+        assert!(!urls.is_empty());
+        for url in &urls {
+            assert!(
+                url.starts_with(
+                    "https://github.com/ggml-org/llama.cpp/releases/download/b10075/llama-b10075-bin-"
+                ),
+                "unexpected pinned url: {url}"
+            );
+            // The whole point of the fallback is to bypass the rate-limited API
+            // (api.github.com), so it must never appear in a fallback URL.
+            assert!(
+                !url.contains("api.github.com"),
+                "pinned fallback must not hit the rate-limited API host: {url}"
+            );
         }
     }
 }

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -527,10 +527,7 @@ impl TranscriptionManager {
                     model_id
                 );
             }
-            EngineType::Parakeet
-            | EngineType::GigaAM
-            | EngineType::Canary
-            | EngineType::Cohere => {
+            EngineType::Parakeet | EngineType::GigaAM | EngineType::Canary | EngineType::Cohere => {
                 // Restore the user's resolved ORT preference in case a previous
                 // load pinned CPU for one of the families above.
                 apply_accelerator_settings(&self.app_handle);

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -654,6 +654,26 @@ impl Default for KeyboardImplementation {
     }
 }
 
+/// What happens when the user closes the main window.
+///
+/// `MinimizeToTray` (the default) preserves the long-standing behavior: the
+/// window hides and the app keeps running in the tray/menubar so global
+/// hotkeys stay live. `Quit` fully exits the process on window close, for
+/// users who don't want a background process (see GitHub issue #6).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum CloseBehavior {
+    MinimizeToTray,
+    Quit,
+}
+
+impl Default for CloseBehavior {
+    fn default() -> Self {
+        // Preserve the historical behavior for everyone unless they opt in.
+        CloseBehavior::MinimizeToTray
+    }
+}
+
 impl Default for ModelUnloadTimeout {
     fn default() -> Self {
         ModelUnloadTimeout::Min5
@@ -1068,6 +1088,8 @@ pub struct AppSettings {
     pub keyboard_implementation: KeyboardImplementation,
     #[serde(default = "default_show_tray_icon")]
     pub show_tray_icon: bool,
+    #[serde(default)]
+    pub close_behavior: CloseBehavior,
     #[serde(default = "default_paste_delay_ms")]
     pub paste_delay_ms: u64,
     #[serde(default = "default_typing_tool")]
@@ -2454,6 +2476,7 @@ pub fn get_default_settings() -> AppSettings {
         lazy_stream_close: false,
         keyboard_implementation: KeyboardImplementation::default(),
         show_tray_icon: default_show_tray_icon(),
+        close_behavior: CloseBehavior::default(),
         paste_delay_ms: default_paste_delay_ms(),
         typing_tool: default_typing_tool(),
         external_script_path: None,

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -22,7 +22,7 @@ use tauri_plugin_autostart::ManagerExt;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use crate::settings::APPLE_INTELLIGENCE_DEFAULT_MODEL_ID;
 use crate::settings::{
-    self, get_settings, AutoSubmitKey, ClipboardHandling, CustomPostProcessTone,
+    self, get_settings, AutoSubmitKey, ClipboardHandling, CloseBehavior, CustomPostProcessTone,
     KeyboardImplementation, LLMPrompt, OverlayPosition, PasteMethod, PostProcessTone,
     ShortcutBinding, SoundTheme, Theme, TypingTool, UiTextSize, APPLE_INTELLIGENCE_PROVIDER_ID,
     DEFAULT_POST_PROCESS_TONE_ID,
@@ -1531,6 +1531,30 @@ pub fn change_show_tray_icon_setting(app: AppHandle, enabled: bool) -> Result<()
     // Apply change immediately
     tray::set_tray_visibility(&app, enabled);
 
+    Ok(())
+}
+
+/// Set what closing the main window does: minimize to the tray (default) or
+/// fully quit the app. The `Quit` branch reuses the same `app.exit(0)` path as
+/// the tray "Quit" item (see the `CloseRequested` handler in `lib.rs`). See
+/// GitHub issue #6.
+#[tauri::command]
+#[specta::specta]
+pub fn change_close_behavior_setting(app: AppHandle, behavior: String) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    let parsed = match behavior.as_str() {
+        "minimize_to_tray" => CloseBehavior::MinimizeToTray,
+        "quit" => CloseBehavior::Quit,
+        other => {
+            warn!(
+                "Invalid close behavior '{}', defaulting to minimize_to_tray",
+                other
+            );
+            CloseBehavior::MinimizeToTray
+        }
+    };
+    settings.close_behavior = parsed;
+    settings::write_settings(&app, settings);
     Ok(())
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SpeakoFlow",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.abhishekbarali.speakoflow",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-tauri/vendor/handy-keys/src/platform/linux/listener.rs
+++ b/src-tauri/vendor/handy-keys/src/platform/linux/listener.rs
@@ -36,6 +36,11 @@ pub(crate) fn spawn(blocking_hotkeys: Option<BlockingHotkeys>) -> Result<LinuxLi
     let thread_running = Arc::clone(&running);
 
     let handle = thread::spawn(move || {
+        // Backoff + attempt tracking so a persistent grab failure (e.g. a
+        // missing `/dev/input` permission on Linux) can't spam the log every
+        // 2s forever, and so an unrecoverable permission error stops cleanly.
+        let mut attempts: u32 = 0;
+        let mut backoff = std::time::Duration::from_secs(2);
         loop {
             let cb_state = Arc::clone(&thread_state);
             let cb_running = Arc::clone(&thread_running);
@@ -145,11 +150,52 @@ pub(crate) fn spawn(blocking_hotkeys: Option<BlockingHotkeys>) -> Result<LinuxLi
             match rdev::grab(callback) {
                 Ok(()) => break,
                 Err(e) => {
-                    eprintln!("rdev grab error: {:?}, retrying in 2s", e);
+                    // Detect the common Linux case: no permission to read
+                    // `/dev/input/event*` (the user isn't in the `input` group).
+                    // We match on the Debug string rather than the GrabError
+                    // variant so this stays robust across rdev versions. errno
+                    // 13 == EACCES == PermissionDenied.
+                    let detail = format!("{:?}", e);
+                    let is_permission_denied =
+                        detail.contains("PermissionDenied") || detail.contains("code: 13");
+
+                    if is_permission_denied {
+                        // This never self-heals within the session (group
+                        // membership needs a re-login), so retrying every 2s
+                        // just spams the log — surface one actionable message
+                        // and stop the listener thread.
+                        eprintln!(
+                            "handy-keys: keyboard capture disabled on Linux — permission denied \
+                             reading /dev/input (errno 13). Global hotkeys will not work. \
+                             Fix: add your user to the 'input' group with \
+                             `sudo usermod -aG input $USER`, then log out and back in. \
+                             Alternatively, switch the keyboard engine to 'Tauri' in Settings \
+                             (it does not require the input group)."
+                        );
+                        break;
+                    }
+
+                    // Other (possibly transient) errors: keep retrying, but with
+                    // capped exponential backoff and quiet logging so a stuck
+                    // state doesn't flood stderr.
+                    attempts += 1;
+                    if attempts <= 3 {
+                        eprintln!(
+                            "rdev grab error: {:?}, retrying in {}s",
+                            e,
+                            backoff.as_secs()
+                        );
+                    } else if attempts == 4 {
+                        eprintln!(
+                            "rdev grab error persists; continuing to retry quietly with backoff."
+                        );
+                    }
+
                     if !thread_running.load(Ordering::SeqCst) {
                         break;
                     }
-                    std::thread::sleep(std::time::Duration::from_secs(2));
+                    std::thread::sleep(backoff);
+                    backoff = (backoff * 2).min(std::time::Duration::from_secs(30));
                 }
             }
         }

--- a/src/assistant/AssistantPanel.tsx
+++ b/src/assistant/AssistantPanel.tsx
@@ -41,6 +41,7 @@ import { syncLanguageFromSettings } from "@/i18n";
 import { AudioWaveform } from "@/components/shared";
 import { FONT_SIZES, errorKind, type AssistantError } from "./appearance";
 import { useKokoroTts } from "./useKokoroTts";
+import { useLocalLlmEngineStatus } from "@/hooks/useLocalLlmEngineStatus";
 import "./AssistantPanel.css";
 
 type AssistantState =
@@ -410,6 +411,19 @@ const AssistantPanel: React.FC = () => {
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([]);
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
   const [dropActive, setDropActive] = useState(false);
+
+  // Built-in (llama.cpp) engine setup progress. Lets the panel show "Setting up
+  // the local engine…" during the one-time first-run download instead of a
+  // silent "Thinking…" (or, on failure, a cryptic "Model couldn't start").
+  const engine = useLocalLlmEngineStatus();
+  const engineSetupActive = engine.active;
+  const engineSetupLabel = engineSetupActive
+    ? engine.phase === "extracting"
+      ? t("assistant.engineSetup.extracting")
+      : engine.total > 0
+        ? t("assistant.engineSetup.downloading", { percent: engine.pct })
+        : t("assistant.engineSetup.preparing")
+    : "";
   const listRef = useRef<HTMLDivElement>(null);
   const sendingRef = useRef(false);
   // Streaming is smoothed: raw tokens accumulate in a buffer and are flushed to
@@ -1180,13 +1194,15 @@ const AssistantPanel: React.FC = () => {
 
     const pillStatus = showError
       ? errorShort(error)
-      : tts.status === "loading"
-        ? t("assistant.tts.loadingShort", { progress: tts.progress })
-        : busy
-          ? t(`assistant.status.${state}`)
-          : ttsActive
-            ? t("assistant.status.speaking")
-            : t("assistant.pill.idle");
+      : engineSetupActive
+        ? engineSetupLabel || t("assistant.engineSetup.short")
+        : tts.status === "loading"
+          ? t("assistant.tts.loadingShort", { progress: tts.progress })
+          : busy
+            ? t(`assistant.status.${state}`)
+            : ttsActive
+              ? t("assistant.status.speaking")
+              : t("assistant.pill.idle");
 
     const waveMode: "reactive" | "shimmer" | "flow" = isListening
       ? "reactive"
@@ -1585,6 +1601,12 @@ const AssistantPanel: React.FC = () => {
             <div className="assistant-notice" role="status">
               <Loader2 size={12} strokeWidth={2} className="apill-spin" />
               {t("assistant.summarizing")}
+            </div>
+          )}
+          {engineSetupActive && (
+            <div className="assistant-notice" role="status" aria-live="polite">
+              <Loader2 size={12} strokeWidth={2} className="apill-spin" />
+              {engineSetupLabel}
             </div>
           )}
           {stream !== "" && (

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -621,6 +621,14 @@ async changeShowTrayIconSetting(enabled: boolean) : Promise<Result<null, string>
     else return { status: "error", error: e  as any };
 }
 },
+async changeCloseBehaviorSetting(behavior: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_close_behavior_setting", { behavior }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeWhisperAcceleratorSetting(accelerator: WhisperAcceleratorSetting) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_whisper_accelerator_setting", { accelerator }) };
@@ -2221,7 +2229,7 @@ flow_phrase?: string;
  * clearly refers to the screen. Separate from the assistant's screen
  * access mode on purpose — the two features are permissioned independently.
  */
-flow_screen_access?: boolean; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number; assistant_provider_id?: string; assistant_models?: Partial<{ [key in string]: string }>; assistant_system_prompt?: string; 
+flow_screen_access?: boolean; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; experimental_enabled?: boolean; lazy_stream_close?: boolean; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; close_behavior?: CloseBehavior; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; custom_filler_words?: string[] | null; whisper_accelerator?: WhisperAcceleratorSetting; ort_accelerator?: OrtAcceleratorSetting; whisper_gpu_device?: number; extra_recording_buffer_ms?: number; assistant_provider_id?: string; assistant_models?: Partial<{ [key in string]: string }>; assistant_system_prompt?: string; 
 /**
  * Controls whether screen capture is off, user-triggered, or agent-decided.
  */
@@ -2671,6 +2679,7 @@ export type ImplementationChangeResult = { success: boolean;
  * List of binding IDs that were reset to defaults due to incompatibility
  */
 reset_bindings: string[] }
+export type CloseBehavior = "minimize_to_tray" | "quit"
 export type KeyboardImplementation = "tauri" | "handy_keys"
 export type LLMPrompt = { id: string; name: string; prompt: string }
 export type LocalLlmStatus = { 

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -23,7 +23,14 @@ const Footer: React.FC = () => {
   }, []);
 
   return (
-    <div className="w-full border-t border-hairline bg-canvas-soft">
+    // `relative z-50` gives the footer its own stacking context ABOVE the
+    // scroll area's content (which sits at `z-10` and would otherwise bubble to
+    // the root stacking context and paint over this static footer). Without it
+    // the centered download indicator — and especially its upward-opening
+    // details popover — got painted behind settings rows and "disappeared"
+    // while scrolling. The footer never scrolls (it's a fixed flex sibling), so
+    // this only fixes paint order, nothing else.
+    <div className="relative z-50 w-full border-t border-hairline bg-canvas-soft">
       {/* About and tray actions still use this controller's event listener, but
           update status no longer competes for permanent footer space. */}
       <UpdateChecker className="hidden" />

--- a/src/components/model-selector/DownloadIndicator.tsx
+++ b/src/components/model-selector/DownloadIndicator.tsx
@@ -143,7 +143,9 @@ const DownloadIndicator: React.FC = () => {
     const downloading = items.filter((i) => i.phase === "downloading");
     if (downloading.length === 1) {
       return {
-        label: t("modelSelector.downloading", { percentage: downloading[0].pct }),
+        label: t("modelSelector.downloading", {
+          percentage: downloading[0].pct,
+        }),
         pct: downloading[0].pct,
         showRing: true,
       };
@@ -158,7 +160,11 @@ const DownloadIndicator: React.FC = () => {
       };
     }
     if (items.some((i) => i.phase === "verifying")) {
-      return { label: t("modelSelector.verifyingGeneric"), pct: 0, showRing: false };
+      return {
+        label: t("modelSelector.verifyingGeneric"),
+        pct: 0,
+        showRing: false,
+      };
     }
     if (items.some((i) => i.phase === "extracting")) {
       return {
@@ -223,7 +229,7 @@ const DownloadIndicator: React.FC = () => {
         <div
           role="status"
           aria-live="polite"
-          className="absolute bottom-full left-1/2 mb-2 w-80 -translate-x-1/2 space-y-3 rounded-xl border border-hairline bg-surface p-3 shadow-[0_16px_40px_rgba(0,0,0,0.24)]"
+          className="absolute bottom-full left-1/2 z-50 mb-2 w-80 -translate-x-1/2 space-y-3 rounded-xl border border-hairline bg-surface p-3 shadow-[0_16px_40px_rgba(0,0,0,0.24)]"
         >
           {items.map((item) => {
             const indeterminate = item.phase !== "downloading";
@@ -250,7 +256,9 @@ const DownloadIndicator: React.FC = () => {
                         ? "w-full animate-pulse"
                         : "transition-all duration-300"
                     }`}
-                    style={indeterminate ? undefined : { width: `${item.pct}%` }}
+                    style={
+                      indeterminate ? undefined : { width: `${item.pct}%` }
+                    }
                   />
                 </div>
                 {!indeterminate && (

--- a/src/components/settings/QuitOnClose.tsx
+++ b/src/components/settings/QuitOnClose.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ToggleSwitch } from "../ui/ToggleSwitch";
+import { useSettings } from "../../hooks/useSettings";
+
+interface QuitOnCloseProps {
+  descriptionMode?: "inline" | "tooltip";
+  grouped?: boolean;
+}
+
+/**
+ * Lets the user choose what closing the main window does (GitHub issue #6).
+ *
+ * The backing setting is a string enum ("minimize_to_tray" | "quit"). The
+ * default stays "minimize_to_tray" so existing behavior is preserved for
+ * everyone; this toggle maps ON -> quit, OFF -> minimize to tray.
+ */
+export const QuitOnClose: React.FC<QuitOnCloseProps> = React.memo(
+  ({ descriptionMode = "tooltip", grouped = false }) => {
+    const { t } = useTranslation();
+    const { getSetting, updateSetting, isUpdating } = useSettings();
+
+    const closeBehavior = getSetting("close_behavior") ?? "minimize_to_tray";
+    const quitOnClose = closeBehavior === "quit";
+
+    return (
+      <ToggleSwitch
+        checked={quitOnClose}
+        onChange={(enabled) =>
+          updateSetting(
+            "close_behavior",
+            enabled ? "quit" : "minimize_to_tray",
+          )
+        }
+        isUpdating={isUpdating("close_behavior")}
+        label={t("settings.advanced.closeBehavior.label")}
+        description={t("settings.advanced.closeBehavior.description")}
+        descriptionMode={descriptionMode}
+        grouped={grouped}
+        tooltipPosition="bottom"
+      />
+    );
+  },
+);

--- a/src/components/settings/assistant/AssistantSettings.tsx
+++ b/src/components/settings/assistant/AssistantSettings.tsx
@@ -45,6 +45,7 @@ import { FONT_SIZES } from "../../../assistant/appearance";
 import "../../../assistant/AssistantPanel.css";
 import { useModelStore } from "@/stores/modelStore";
 import { getModelCategory } from "@/lib/utils/modelCategory";
+import { useLocalLlmEngineStatus } from "@/hooks/useLocalLlmEngineStatus";
 import ScreenRecordingPermission from "@/components/ScreenRecordingPermission";
 
 /** The built-in (local) llama.cpp provider id, mirrored from the backend. */
@@ -192,6 +193,10 @@ export const AssistantSettings: React.FC<AssistantSettingsProps> = ({
   const [localLlmStatus, setLocalLlmStatus] = useState<LocalLlmStatus | null>(
     null,
   );
+  // Live built-in engine (llama.cpp binary) setup progress, shared with the
+  // assistant panel via the same backend events, so this form can show the
+  // one-time first-run engine download instead of leaving it invisible.
+  const engineStatus = useLocalLlmEngineStatus();
   useEffect(() => {
     if (!isBuiltin) return;
     let active = true;
@@ -954,10 +959,43 @@ export const AssistantSettings: React.FC<AssistantSettingsProps> = ({
               {t("settings.assistant.provider.builtinNoModels")}
             </span>
           )}
-          {localLlmStatus && !localLlmStatus.engine_present && (
-            <span className="text-xs text-amber-500 max-w-[360px] text-right">
-              {t("settings.assistant.provider.builtinEngineMissing")}
-            </span>
+          {engineStatus.active ? (
+            <div className="flex w-full max-w-[360px] flex-col items-end gap-1">
+              <span className="inline-flex items-center gap-1.5 text-xs text-muted">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                {engineStatus.phase === "extracting"
+                  ? t("settings.assistant.provider.builtinEngineExtracting")
+                  : engineStatus.total > 0
+                    ? t(
+                        "settings.assistant.provider.builtinEngineDownloading",
+                        {
+                          percent: engineStatus.pct,
+                        },
+                      )
+                    : t("settings.assistant.provider.builtinEnginePreparing")}
+              </span>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-hairline-strong">
+                <div
+                  className={`h-full rounded-full bg-accent ${
+                    engineStatus.total > 0
+                      ? "transition-[width] duration-200"
+                      : "w-full animate-pulse"
+                  }`}
+                  style={
+                    engineStatus.total > 0
+                      ? { width: `${engineStatus.pct}%` }
+                      : undefined
+                  }
+                />
+              </div>
+            </div>
+          ) : (
+            localLlmStatus &&
+            !localLlmStatus.engine_present && (
+              <span className="text-xs text-amber-500 max-w-[360px] text-right">
+                {t("settings.assistant.provider.builtinEngineMissing")}
+              </span>
+            )
           )}
         </div>
       </SettingContainer>

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -26,6 +26,7 @@ import { MuteWhileRecording } from "../MuteWhileRecording";
 import { AutostartToggle } from "../AutostartToggle";
 import { StartHidden } from "../StartHidden";
 import { ShowTrayIcon } from "../ShowTrayIcon";
+import { QuitOnClose } from "../QuitOnClose";
 import { OverlayStyle } from "../OverlayStyle";
 import { ShowOverlay } from "../ShowOverlay";
 import { UpdateChecksToggle } from "../UpdateChecksToggle";
@@ -114,6 +115,7 @@ export const GeneralSettings: React.FC = () => {
         <AutostartToggle descriptionMode="tooltip" grouped={true} />
         <StartHidden descriptionMode="tooltip" grouped={true} />
         <ShowTrayIcon descriptionMode="tooltip" grouped={true} />
+        <QuitOnClose descriptionMode="tooltip" grouped={true} />
         <UpdateChecksToggle descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
 

--- a/src/hooks/useLocalLlmEngineStatus.ts
+++ b/src/hooks/useLocalLlmEngineStatus.ts
@@ -1,0 +1,127 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+/**
+ * Setup phase of the built-in (llama.cpp) engine binary. This is the ENGINE
+ * download — the one-time fetch of `llama-server` on first use — which is
+ * separate from downloading a GGUF model. `null` means nothing is happening.
+ */
+export type LocalLlmEnginePhase =
+  | "downloading"
+  | "extracting"
+  | "ready"
+  | "error"
+  | null;
+
+export interface LocalLlmEngineStatus {
+  phase: LocalLlmEnginePhase;
+  /** Bytes downloaded so far (0 until the first progress event). */
+  downloaded: number;
+  /** Total bytes, or 0 when the server didn't report a Content-Length. */
+  total: number;
+  /** 0–100, or 0 when the total is unknown (show an indeterminate bar then). */
+  pct: number;
+  /** True while the engine is actively downloading or extracting. */
+  active: boolean;
+}
+
+const IDLE: LocalLlmEngineStatus = {
+  phase: null,
+  downloaded: 0,
+  total: 0,
+  pct: 0,
+  active: false,
+};
+
+/**
+ * Subscribe to the built-in engine's setup lifecycle. The backend
+ * (`managers/local_llm.rs`) emits `local-llm-engine-status`
+ * ("downloading" | "extracting" | "ready" | "error") and
+ * `local-llm-engine-progress` ({ downloaded, total }) during the first-run
+ * engine download. Tauri broadcasts app-level events to every window, so this
+ * works in both the settings window and the floating assistant panel.
+ *
+ * Before this, those events were emitted but nothing listened — so the very
+ * first assistant turn silently downloaded ~100MB with zero feedback, and a
+ * failure surfaced only as a cryptic "Model couldn't start". This hook is the
+ * consumer that makes that setup visible.
+ */
+export function useLocalLlmEngineStatus(): LocalLlmEngineStatus {
+  const [status, setStatus] = useState<LocalLlmEngineStatus>(IDLE);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlistenStatus: (() => void) | undefined;
+    let unlistenProgress: (() => void) | undefined;
+    let clearTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const stopClearTimer = () => {
+      if (clearTimer) {
+        clearTimeout(clearTimer);
+        clearTimer = undefined;
+      }
+    };
+
+    void (async () => {
+      const s = await listen<string>("local-llm-engine-status", (event) => {
+        const phase = event.payload as LocalLlmEnginePhase;
+        stopClearTimer();
+        if (phase === "ready" || phase === "error") {
+          // Show the terminal state briefly, then reset so a stale banner never
+          // lingers over a later, healthy turn.
+          setStatus((prev) => ({ ...prev, phase, active: false }));
+          clearTimer = setTimeout(() => {
+            if (!disposed) setStatus(IDLE);
+          }, 2000);
+          return;
+        }
+        setStatus((prev) => ({
+          ...prev,
+          phase,
+          active: phase === "downloading" || phase === "extracting",
+        }));
+      });
+
+      const p = await listen<{ downloaded: number; total: number }>(
+        "local-llm-engine-progress",
+        (event) => {
+          const { downloaded, total } = event.payload;
+          const pct =
+            total > 0
+              ? Math.max(
+                  0,
+                  Math.min(100, Math.round((downloaded / total) * 100)),
+                )
+              : 0;
+          stopClearTimer();
+          setStatus((prev) => ({
+            // A progress tick means we're downloading, unless we've already
+            // advanced to extracting.
+            phase: prev.phase === "extracting" ? "extracting" : "downloading",
+            downloaded,
+            total,
+            pct,
+            active: true,
+          }));
+        },
+      );
+
+      if (disposed) {
+        s();
+        p();
+        return;
+      }
+      unlistenStatus = s;
+      unlistenProgress = p;
+    })();
+
+    return () => {
+      disposed = true;
+      stopClearTimer();
+      unlistenStatus?.();
+      unlistenProgress?.();
+    };
+  }, []);
+
+  return status;
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -604,6 +604,10 @@
         "label": "Show tray icon",
         "description": "Keep SpeakoFlow in your system tray."
       },
+      "closeBehavior": {
+        "label": "Quit when I close the window",
+        "description": "When off, closing the window keeps SpeakoFlow running in the tray so your hotkeys still work. When on, closing the window quits the app completely."
+      },
       "overlayStyle": {
         "title": "Overlay",
         "description": "How the recording overlay looks while you dictate. None hides it, Minimal is the compact pill, and Live shows a readable card with your words as you speak (for models that support it).",
@@ -1133,6 +1137,10 @@
         "builtinNoModels": "No models on your machine yet — download one below.",
         "builtinReady": "Runs fully on your machine. No API key, no setup.",
         "builtinEngineMissing": "First use downloads a small local engine automatically (one time), then runs fully offline. No setup needed.",
+        "builtinEngineDownloading": "Downloading the local engine… {{percent}}%",
+        "builtinEnginePreparing": "Downloading the local engine…",
+        "builtinEngineExtracting": "Installing the local engine…",
+        "builtinEngineReady": "Local engine ready.",
         "contextSizeLabel": "Context window",
         "contextSizeDescription": "How much the local model can keep in mind at once — the system instructions, your chat history, any screenshot (a single image can eat a big chunk), and its reply. Bigger holds more and keeps screen vision and web search reliable, but uses more memory. The default is 8192; 16384 is a good step up if your machine has the RAM to spare. You can lower it later to save memory.",
         "unloadTimeoutLabel": "Unload from memory after",
@@ -1564,6 +1572,12 @@
     "notices": {
       "web_search_failed": "Web search didn't return results — answering without them.",
       "web_search_failedShort": "No web results"
+    },
+    "engineSetup": {
+      "downloading": "Setting up the local engine (first run)… {{percent}}%",
+      "preparing": "Setting up the local engine (first run)…",
+      "extracting": "Installing the local engine…",
+      "short": "Setting up engine…"
     }
   }
 }

--- a/src/lib/utils/keyboard.ts
+++ b/src/lib/utils/keyboard.ts
@@ -169,24 +169,45 @@ const capitalizeKey = (key: string): string => {
 };
 
 /**
+ * Tokens that all refer to the "meta" / left-of-space command key. The stored
+ * hotkey token is always "super" (what the backend shortcut engines expect),
+ * but historical capture paths could also produce "win"/"windows"/"meta", so we
+ * recognize the whole family for display purposes.
+ */
+const META_KEY_ALIASES = new Set(["super", "win", "windows", "meta"]);
+
+/**
  * Format a single key part for display.
  * Handles _left/_right suffixes and capitalizes names.
  * e.g. "shift_left" -> "Left Shift", "option" -> "Option", "space" -> "Space"
+ *
+ * The meta key is branded per-OS for DISPLAY ONLY (the stored token stays
+ * "super", so the backend is unaffected): Windows users see "Windows" instead
+ * of the confusing "Super", while Linux keeps "Super" and macOS is unaffected
+ * (it stores "command", not "super").
  */
-const formatKeyPart = (part: string): string => {
+const formatKeyPart = (part: string, osType: OSType = "unknown"): string => {
   const trimmed = part.trim();
   if (!trimmed) return "";
 
+  let side = "";
+  let name = trimmed;
   if (trimmed.endsWith("_left")) {
-    const name = trimmed.slice(0, -5);
-    return `Left ${capitalizeKey(name)}`;
-  }
-  if (trimmed.endsWith("_right")) {
-    const name = trimmed.slice(0, -6);
-    return `Right ${capitalizeKey(name)}`;
+    side = "Left ";
+    name = trimmed.slice(0, -5);
+  } else if (trimmed.endsWith("_right")) {
+    side = "Right ";
+    name = trimmed.slice(0, -6);
   }
 
-  return capitalizeKey(trimmed);
+  // Windows: show the ⊞ key as "Windows" rather than "Super". This is purely a
+  // relabel — the underlying stored value ("super") is untouched, so the global
+  // shortcut engine still binds exactly the same key. Linux/macOS unchanged.
+  if (osType === "windows" && META_KEY_ALIASES.has(name.toLowerCase())) {
+    return `${side}Windows`;
+  }
+
+  return `${side}${capitalizeKey(name)}`;
 };
 
 /**
@@ -196,10 +217,13 @@ const formatKeyPart = (part: string): string => {
  */
 export const formatKeyCombination = (
   combination: string,
-  _osType: OSType,
+  osType: OSType = "unknown",
 ): string => {
   if (!combination) return "";
-  return combination.split("+").map(formatKeyPart).join(" + ");
+  return combination
+    .split("+")
+    .map((part) => formatKeyPart(part, osType))
+    .join(" + ");
 };
 
 /**

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -228,6 +228,8 @@ const settingUpdaters: {
     commands.changeLiveTranscriptionWindowEnabledSetting(value as boolean),
   show_tray_icon: (value) =>
     commands.changeShowTrayIconSetting(value as boolean),
+  close_behavior: (value) =>
+    commands.changeCloseBehaviorSetting(value as string),
   whisper_accelerator: (value) =>
     commands.changeWhisperAcceleratorSetting(
       value as WhisperAcceleratorSetting,


### PR DESCRIPTION
## Summary

Cuts **v1.0.1** with this session's fixes and improvements. All of it is new work — the memory/disk fix from #3 is already on `main`, so this PR contains only the changes on top. Version bumped to `1.0.1` across `package.json`, `tauri.conf.json`, and `Cargo.toml`.

### Changes

**Fixes**
- **Gemini models** — strip the `models/` prefix the Gemini `/models` endpoint returns, so the chat endpoint accepts the IDs the picker lists (Gemini previously failed while other providers worked). It's the shared LLM client, so this fixes both the Assistant and dictation AI‑cleanup. Adds regression tests.
- **Windows key label** — the meta key now displays as "Windows" instead of "Super" (display only).
- **Download indicator** — given an explicit stacking context so it always overlays content instead of slipping behind it.
- **Linux input permission (#5)** — the handy-keys rdev listener no longer spams `Permission denied` every 2s forever. It detects the missing `input`-group case, logs one actionable message (add your user to the `input` group, or switch to the Tauri keyboard engine), and stops; other errors use capped backoff.

**Feature**
- **Quit-on-close (#6)** — a "Quit when I close the window" toggle in Settings → General → Startup. **Off by default** (behavior unchanged: minimize to tray); when on, closing the window fully quits via the same clean exit path as the tray Quit item.

**Engine UX**
- Built-in LLM engine install hardened (clearer errors, pinned-asset fallback, macOS/Linux tar.gz extraction) with first-run download/extract progress surfaced in the assistant panel and settings.

**Docs**
- `docs/PROVIDER_AUDIT.md` — live-verified every LLM / web-search / TTS provider (2026-07-21); Gemini was the sole model-name drift.
- `README.md` — Linux troubleshooting for the input-group permission issue and the WebKitGTK pinch-to-zoom crash (an upstream bug, documented with a workaround).

### Testing
- Backend: `cargo test --lib` → **277 passed, 0 failed**; `cargo fmt` clean; `cargo clippy` shows only pre-existing style warnings.
- Frontend: `tsc --noEmit` clean; `eslint` clean; `bun run build` succeeds.
- Verified on Windows. The Linux-only rdev change and the pinch-to-zoom crash (upstream WebKitGTK) could **not** be built or run on Linux hardware from the dev machine; both are `cfg`-isolated so they cannot affect the Windows/macOS builds.

### Not included / follow-ups
- The pinch-to-zoom crash is **documented only** — it's an upstream WebKitGTK bug ([tauri#13115](https://github.com/tauri-apps/tauri/issues/13115), [wry#544](https://github.com/tauri-apps/wry/issues/544)) with no clean, verifiable app-side fix.
- This release is **unsigned** (draft): Windows SmartScreen / macOS Gatekeeper will warn, and auto-update is disabled.

---
_Prepared with AI assistance (Kiro). Verified as noted above._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Quit on close” setting, allowing the app to exit or minimize to the tray.
  * Added visible progress updates during built-in local AI engine setup.
  * Improved Windows shortcut labels by displaying “Windows” for applicable keys.

* **Bug Fixes**
  * Improved Gemini model compatibility.
  * Made local engine downloads more resilient, including fallback downloads and archive formats.
  * Improved Linux hotkey permission handling and download indicator visibility.

* **Documentation**
  * Added Linux troubleshooting guidance for hotkey permissions and touchpad pinch-to-zoom crashes.
  * Updated provider compatibility audit information.

* **Release**
  * Version updated to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->