### PR TITLE
fix: Gemini tool calls across rounds + Linux device-probe crash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ SpeakoFlow is a cross-platform desktop voice assistant (dictation, AI chat panel
 - `managers/` - Core business logic:
   - `audio.rs` - Audio recording and device management
   - `model.rs` - Model downloading and management: resilient downloads that auto-retry with exponential backoff and resume from a `.partial` file via HTTP `Range` (`attempt_download`, `AttemptOutcome`, `HttpStatusError` sorting transient vs. permanent failures), plus an ordered source list — a reliable mirror first, the canonical Hugging Face URL as fallback (`download_candidates` / `mirror_url_for`; mirrors not yet populated, see `docs/TODO_BEFORE_RELEASE.md`)
-  - `transcription.rs` - Speech-to-text processing pipeline
+  - `transcription.rs` - Speech-to-text processing pipeline. Compute-device enumeration is crash-isolated on Linux: `PROBE_DEVICES_OUT_OF_PROCESS` (true only on Linux) sends `cached_gpu_devices` / `cached_transcribe_cpp_devices` through `probe_devices_out_of_process`, which spawns `self --probe-devices` and parses one line of JSON. The vendored, statically linked whisper.cpp/ggml in `transcribe-rs` is built with ggml's default `GGML_NATIVE=ON` (`-march=native`), so loading its Vulkan backend can raise SIGILL when a package runs on a narrower CPU than the one that built it — out of process, that costs a GPU listing instead of the whole app at launch. Windows/macOS keep the in-process call unchanged
   - `history.rs` - Transcription history storage
 - `audio_toolkit/` - Low-level audio processing:
   - `audio/` - Device enumeration, recording, resampling

--- a/src-tauri/src/assistant.rs
+++ b/src-tauri/src/assistant.rs
@@ -2375,11 +2375,23 @@ pub async fn run_assistant_turn(
                     .tool_calls
                     .iter()
                     .map(|tc| {
-                        json!({
+                        let mut call = json!({
                             "id": tc.id,
                             "type": "function",
                             "function": { "name": tc.name, "arguments": tc.arguments }
-                        })
+                        });
+                        // Gemini thinking models reject the follow-up request
+                        // ("Function call is missing a thought_signature in
+                        // functionCall parts", HTTP 400) unless the opaque
+                        // signature that came back with the call is echoed
+                        // verbatim, in exactly this shape. Added only when the
+                        // provider actually sent one, so requests to every other
+                        // OpenAI-compatible provider stay byte-identical.
+                        if let Some(signature) = &tc.thought_signature {
+                            call["extra_content"] =
+                                json!({ "google": { "thought_signature": signature } });
+                        }
+                        call
                     })
                     .collect();
                 msgs.push(json!({
@@ -3167,6 +3179,7 @@ mod tests {
                 id: "call-1".to_string(),
                 name: "get_current_datetime".to_string(),
                 arguments: "{}".to_string(),
+                thought_signature: None,
             }],
         }
         .into();

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -33,4 +33,13 @@ pub struct CliArgs {
     /// with no dev toolchain / no Vulkan SDK (the Session 7 clean-machine gate).
     #[arg(long)]
     pub list_devices: bool,
+
+    /// Internal: enumerate the compute devices, print them as one line of JSON,
+    /// and exit. The app spawns itself with this on Linux so that a SIGILL or a
+    /// hang inside the vendored ggml/Vulkan code kills only this short-lived
+    /// child instead of the app at launch (see
+    /// `managers::transcription::probe_devices_out_of_process`). Hidden because
+    /// it is an implementation detail, not a user-facing switch.
+    #[arg(long, hide = true)]
+    pub probe_devices: bool,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -475,6 +475,28 @@ pub fn list_transcribe_devices() {
     }
 }
 
+/// Handle the `--probe-devices` flag: enumerate the compute devices in this
+/// short-lived process and print them as a single line of JSON, then return so
+/// the process exits without launching the GUI.
+///
+/// This is the child half of the Linux crash-isolated device probe. The running
+/// app spawns itself with this flag instead of loading ggml's Vulkan backend
+/// in-process, because the vendored, statically linked whisper.cpp/ggml is built
+/// with `-march=native` and can raise SIGILL on a machine narrower than the one
+/// that built the package. If that happens the child dies here and the app just
+/// carries on without GPU acceleration.
+pub fn print_device_probe_json() {
+    // The backend modules must be loaded before transcribe.cpp can report any
+    // devices; harmless for the whisper probe.
+    managers::transcription::init_transcribe_cpp();
+
+    let probe = managers::transcription::enumerate_devices_in_process();
+    match serde_json::to_string(&probe) {
+        Ok(json) => println!("{json}"),
+        Err(error) => eprintln!("device probe serialization failed: {error}"),
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run(cli_args: CliArgs) {
     // Detect portable mode before anything else

--- a/src-tauri/src/llm_client.rs
+++ b/src-tauri/src/llm_client.rs
@@ -523,6 +523,10 @@ struct StreamToolCall {
     id: Option<String>,
     #[serde(default)]
     function: Option<StreamToolCallFn>,
+    /// Gemini-only side channel (see `ToolCall::thought_signature`). Absent on
+    /// every other OpenAI-compatible provider.
+    #[serde(default)]
+    extra_content: Option<StreamToolCallExtra>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -533,6 +537,20 @@ struct StreamToolCallFn {
     arguments: Option<String>,
 }
 
+/// `tool_calls[].extra_content` as Gemini's OpenAI-compatibility layer emits it:
+/// `{"google": {"thought_signature": "<opaque>"}}`.
+#[derive(Debug, Deserialize)]
+struct StreamToolCallExtra {
+    #[serde(default)]
+    google: Option<StreamToolCallGoogleExtra>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamToolCallGoogleExtra {
+    #[serde(default)]
+    thought_signature: Option<String>,
+}
+
 /// A fully-assembled tool call the model asked us to run.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolCall {
@@ -540,6 +558,15 @@ pub struct ToolCall {
     pub name: String,
     /// Raw JSON arguments string (parse at the call site).
     pub arguments: String,
+    /// Gemini thinking models return an opaque, encrypted `thought_signature`
+    /// alongside every function call and require it echoed back verbatim on the
+    /// follow-up request, or the next call fails with
+    /// "Function call is missing a thought_signature in functionCall parts"
+    /// (HTTP 400). It is opaque to us: capture it, carry it, hand it back
+    /// untouched (see the `extra_content` re-attach in `assistant.rs`).
+    /// `None` for every provider that does not send one, which is all of them
+    /// except Gemini — so nothing extra is ever put on the wire elsewhere.
+    pub thought_signature: Option<String>,
 }
 
 /// Outcome of one streamed tool-calling round: any content the model streamed
@@ -569,6 +596,17 @@ impl From<ChatRound> for ToolStreamOutcome {
     }
 }
 
+/// Per-index scratch space while a tool call streams in. Named fields (rather
+/// than a positional tuple) keep the merge below readable now that a fourth,
+/// provider-specific value rides along.
+#[derive(Default)]
+struct ToolCallParts {
+    id: String,
+    name: String,
+    arguments: String,
+    thought_signature: Option<String>,
+}
+
 /// Byte-buffered decoder and accumulator for an OpenAI-compatible SSE chat
 /// round. Complete lines are decoded only after all their bytes arrive, so a
 /// UTF-8 code point may be split across any number of network chunks safely.
@@ -576,7 +614,7 @@ impl From<ChatRound> for ToolStreamOutcome {
 struct SseChatAccumulator {
     pending: Vec<u8>,
     round: ChatRound,
-    tool_call_parts: Vec<(String, String, String)>,
+    tool_call_parts: Vec<ToolCallParts>,
     done: bool,
 }
 
@@ -660,23 +698,36 @@ impl SseChatAccumulator {
         if let Some(tool_calls) = &choice.delta.tool_calls {
             for tool_call in tool_calls {
                 while self.tool_call_parts.len() <= tool_call.index {
-                    self.tool_call_parts
-                        .push((String::new(), String::new(), String::new()));
+                    self.tool_call_parts.push(ToolCallParts::default());
                 }
                 let slot = &mut self.tool_call_parts[tool_call.index];
                 if let Some(id) = &tool_call.id {
                     if !id.is_empty() {
-                        slot.0 = id.clone();
+                        slot.id = id.clone();
                     }
                 }
                 if let Some(function) = &tool_call.function {
                     if let Some(name) = &function.name {
                         if !name.is_empty() {
-                            slot.1 = name.clone();
+                            slot.name = name.clone();
                         }
                     }
                     if let Some(arguments) = &function.arguments {
-                        slot.2.push_str(arguments);
+                        slot.arguments.push_str(arguments);
+                    }
+                }
+                // Gemini may deliver the signature on any chunk for this index
+                // (often a frame of its own, with no function payload), so merge
+                // it by index like everything else and never clobber a captured
+                // value with a later empty one.
+                if let Some(signature) = tool_call
+                    .extra_content
+                    .as_ref()
+                    .and_then(|extra| extra.google.as_ref())
+                    .and_then(|google| google.thought_signature.as_deref())
+                {
+                    if !signature.is_empty() {
+                        slot.thought_signature = Some(signature.to_string());
                     }
                 }
             }
@@ -842,20 +893,21 @@ pub async fn send_chat_stream_with_tools(
     Ok(read_sse_round(response, on_token).await?.into())
 }
 
-/// Turn accumulated (id, name, arguments) fragments into ToolCalls, dropping any
-/// entry without a function name (defensive against malformed streams).
-fn assemble_tool_calls(acc: Vec<(String, String, String)>) -> Vec<ToolCall> {
+/// Turn accumulated tool-call fragments into ToolCalls, dropping any entry
+/// without a function name (defensive against malformed streams).
+fn assemble_tool_calls(acc: Vec<ToolCallParts>) -> Vec<ToolCall> {
     acc.into_iter()
         .enumerate()
-        .filter(|(_, (_, name, _))| !name.is_empty())
-        .map(|(i, (id, name, arguments))| ToolCall {
-            id: if id.is_empty() {
+        .filter(|(_, parts)| !parts.name.is_empty())
+        .map(|(i, parts)| ToolCall {
+            id: if parts.id.is_empty() {
                 format!("call_{}", i)
             } else {
-                id
+                parts.id
             },
-            name,
-            arguments,
+            name: parts.name,
+            arguments: parts.arguments,
+            thought_signature: parts.thought_signature,
         })
         .collect()
 }
@@ -1298,8 +1350,60 @@ mod tests {
                 id: "call_screen".to_string(),
                 name: "capture_screen".to_string(),
                 arguments: "{\"timing\":\"now\"}".to_string(),
+                thought_signature: None,
             }]
         );
+    }
+
+    /// Gemini thinking models return an opaque `thought_signature` with every
+    /// function call and 400 the follow-up request if it is not echoed back. It
+    /// can arrive on a later frame than the call itself, so the decoder has to
+    /// merge it by index like the argument fragments.
+    #[test]
+    fn sse_decoder_captures_gemini_thought_signature_from_extra_content() {
+        let call = serde_json::json!({
+            "choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "id": "call_search",
+                "function": {"name": "web_search", "arguments": "{\"query\":\"rust\"}"}
+            }]}}]
+        });
+        let signature = serde_json::json!({
+            "choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "extra_content": {"google": {"thought_signature": "SIG-ABC"}}
+            }]}}]
+        });
+        let wire = format!("data: {call}\n\ndata: {signature}\n\ndata: [DONE]\n\n");
+
+        let (round, _) = decode_sse(vec![wire.into_bytes()]);
+        assert_eq!(
+            round.tool_calls,
+            [ToolCall {
+                id: "call_search".to_string(),
+                name: "web_search".to_string(),
+                arguments: "{\"query\":\"rust\"}".to_string(),
+                thought_signature: Some("SIG-ABC".to_string()),
+            }]
+        );
+    }
+
+    /// Providers that send no signature must stay at `None`, so nothing extra is
+    /// ever attached to a non-Gemini follow-up request.
+    #[test]
+    fn sse_decoder_leaves_thought_signature_unset_without_extra_content() {
+        let call = serde_json::json!({
+            "choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "id": "call_time",
+                "function": {"name": "get_current_datetime", "arguments": "{}"}
+            }]}}]
+        });
+        let wire = format!("data: {call}\n\ndata: [DONE]\n\n");
+
+        let (round, _) = decode_sse(vec![wire.into_bytes()]);
+        assert_eq!(round.tool_calls.len(), 1);
+        assert_eq!(round.tool_calls[0].thought_signature, None);
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,15 @@ fn main() {
         return;
     }
 
+    // `--probe-devices` is the machine-readable sibling of `--list-devices`, and
+    // the child half of the Linux crash-isolated device probe: one JSON line on
+    // stdout, then exit. Must also stay ahead of any window/single-instance
+    // setup — the parent app is already running when this executes.
+    if cli_args.probe_devices {
+        speakoflow_app_lib::print_device_probe_json();
+        return;
+    }
+
     #[cfg(target_os = "linux")]
     {
         // DMABUF renderer causes crashes on various GPU/display server configurations

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -1894,7 +1894,9 @@ fn resolve_auto_ort_accelerator() -> transcribe_rs::accel::OrtAccelerator {
     OrtAccelerator::Auto
 }
 
-#[derive(Serialize, Clone, Debug, Type)]
+/// One compute device. `Deserialize` is needed by the Linux out-of-process
+/// probe, which parses this back out of the child's JSON.
+#[derive(Serialize, serde::Deserialize, Clone, Debug, Type)]
 pub struct GpuDeviceOption {
     pub id: i32,
     pub name: String,
@@ -1904,34 +1906,169 @@ pub struct GpuDeviceOption {
 
 static GPU_DEVICES: OnceLock<Vec<GpuDeviceOption>> = OnceLock::new();
 
-fn cached_gpu_devices() -> &'static [GpuDeviceOption] {
+/// Both device lists, as produced by one enumeration pass. Serialized to a
+/// single JSON line so the Linux out-of-process probe can hand them back to the
+/// parent (see `probe_devices_out_of_process`).
+#[derive(Serialize, serde::Deserialize, Clone, Debug, Default)]
+pub struct DeviceProbe {
+    pub whisper: Vec<GpuDeviceOption>,
+    pub transcribe_cpp: Vec<GpuDeviceOption>,
+}
+
+/// Enumerate the whisper GPU devices in THIS process.
+///
+/// Loads ggml's Vulkan backend, which is the risky part: the statically linked
+/// whisper.cpp/ggml in `transcribe-rs` is compiled with ggml's default
+/// `GGML_NATIVE=ON` (i.e. `-march=native`), so a package built on a machine with
+/// a wider instruction set than the one running it can raise SIGILL right here —
+/// an uncatchable crash that takes the whole app down at launch. On Linux, where
+/// packages are routinely built on a different machine than they run on, callers
+/// go through `probe_devices_out_of_process` instead so a crash costs us a GPU
+/// listing rather than the app.
+fn enumerate_whisper_gpu_devices() -> Vec<GpuDeviceOption> {
     use transcribe_rs::whisper_cpp::gpu::list_gpu_devices;
 
-    GPU_DEVICES.get_or_init(|| {
-        // ggml's Vulkan backend uses FMA3 instructions internally.
-        // On older CPUs without FMA3 (e.g. Sandy Bridge Xeons) this causes
-        // a SIGILL crash that cannot be caught. Skip enumeration entirely
-        // on those CPUs — GPU-accelerated whisper won't work there anyway.
-        #[cfg(target_arch = "x86_64")]
-        if !std::arch::is_x86_feature_detected!("fma") {
-            warn!("CPU lacks FMA3 support — skipping GPU device enumeration");
-            return Vec::new();
-        }
+    // ggml's Vulkan backend uses FMA3 instructions internally.
+    // On older CPUs without FMA3 (e.g. Sandy Bridge Xeons) this causes
+    // a SIGILL crash that cannot be caught. Skip enumeration entirely
+    // on those CPUs — GPU-accelerated whisper won't work there anyway.
+    #[cfg(target_arch = "x86_64")]
+    if !std::arch::is_x86_feature_detected!("fma") {
+        warn!("CPU lacks FMA3 support — skipping GPU device enumeration");
+        return Vec::new();
+    }
 
-        list_gpu_devices()
-            .into_iter()
-            .map(|d| GpuDeviceOption {
-                id: d.id,
-                name: d.name,
-                kind: match d.kind {
-                    transcribe_rs::whisper_cpp::gpu::GpuKind::Dedicated => "dedicated".to_string(),
-                    transcribe_rs::whisper_cpp::gpu::GpuKind::Integrated => {
-                        "integrated".to_string()
-                    }
-                },
-                total_vram_mb: d.total_vram / (1024 * 1024),
-            })
-            .collect()
+    list_gpu_devices()
+        .into_iter()
+        .map(|d| GpuDeviceOption {
+            id: d.id,
+            name: d.name,
+            kind: match d.kind {
+                transcribe_rs::whisper_cpp::gpu::GpuKind::Dedicated => "dedicated".to_string(),
+                transcribe_rs::whisper_cpp::gpu::GpuKind::Integrated => "integrated".to_string(),
+            },
+            total_vram_mb: d.total_vram / (1024 * 1024),
+        })
+        .collect()
+}
+
+/// Enumerate both device lists in THIS process. Used by the non-Linux (direct)
+/// path and by the `--probe-devices` child on Linux.
+pub fn enumerate_devices_in_process() -> DeviceProbe {
+    DeviceProbe {
+        whisper: enumerate_whisper_gpu_devices(),
+        transcribe_cpp: enumerate_transcribe_cpp_devices(),
+    }
+}
+
+/// Run the whole enumeration in a short-lived CHILD process and parse its JSON.
+///
+/// The point is fault isolation, not speed: if the vendored native code raises
+/// SIGILL (see `enumerate_whisper_gpu_devices`) or wedges on a broken Vulkan
+/// driver, the child dies alone and we degrade to "no GPU listed" — the app
+/// still starts and transcribes on the CPU. Any failure is a warning, never
+/// fatal.
+///
+/// Compiled on every platform (so it stays type-checked) but only reached on
+/// Linux — see `PROBE_DEVICES_OUT_OF_PROCESS`.
+fn probe_devices_out_of_process() -> Result<DeviceProbe, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe failed: {e}"))?;
+    probe_devices_via(&exe)
+}
+
+fn probe_devices_via(exe: &std::path::Path) -> Result<DeviceProbe, String> {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    // Generous: a cold Vulkan driver enumerating several devices can take a few
+    // seconds. This only bounds a hung child.
+    const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+    const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+    let mut child = Command::new(exe)
+        .arg("--probe-devices")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("could not spawn the device probe: {e}"))?;
+
+    // Poll rather than block so a wedged child can be killed. The probe writes
+    // well under a pipe buffer, so leaving stdout unread until exit cannot
+    // deadlock.
+    let deadline = Instant::now() + PROBE_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err("the device probe timed out".to_string());
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(e) => return Err(format!("waiting for the device probe failed: {e}")),
+        }
+    };
+
+    let mut stdout = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        let _ = pipe.read_to_string(&mut stdout);
+    }
+
+    if !status.success() {
+        // The SIGILL case lands here (no exit code, killed by signal).
+        return Err(format!("the device probe exited abnormally ({status})"));
+    }
+
+    parse_device_probe_output(&stdout)
+}
+
+/// Pick the device list out of the child's stdout.
+///
+/// Scans from the end for the last line that parses, so any logging the child
+/// emits before its JSON (a backend-init line, a driver warning) is ignored.
+fn parse_device_probe_output(stdout: &str) -> Result<DeviceProbe, String> {
+    stdout
+        .lines()
+        .rev()
+        .find_map(|line| serde_json::from_str::<DeviceProbe>(line.trim()).ok())
+        .ok_or_else(|| "the device probe produced no parsable output".to_string())
+}
+
+/// Whether device enumeration runs in a child process instead of in-process.
+///
+/// Linux only: that is where a package is routinely built on a different machine
+/// than it runs on, which is exactly when the `-march=native` ggml build can
+/// SIGILL (see `enumerate_whisper_gpu_devices`). Windows and macOS keep the
+/// historical in-process call. A `cfg!` const rather than `#[cfg]` blocks so
+/// both paths stay compiled and type-checked everywhere; the dead branch folds
+/// away at compile time.
+const PROBE_DEVICES_OUT_OF_PROCESS: bool = cfg!(target_os = "linux");
+
+/// Devices for this machine, enumerated once. Linux goes out of process (crash
+/// isolation); every other platform keeps the historical in-process call.
+fn device_probe() -> &'static DeviceProbe {
+    static DEVICE_PROBE: OnceLock<DeviceProbe> = OnceLock::new();
+
+    DEVICE_PROBE.get_or_init(|| match probe_devices_out_of_process() {
+        Ok(probe) => probe,
+        Err(error) => {
+            warn!("Out-of-process device enumeration failed ({error}) — continuing without GPU acceleration. Transcription still works on the CPU.");
+            DeviceProbe::default()
+        }
+    })
+}
+
+fn cached_gpu_devices() -> &'static [GpuDeviceOption] {
+    GPU_DEVICES.get_or_init(|| {
+        if PROBE_DEVICES_OUT_OF_PROCESS {
+            device_probe().whisper.clone()
+        } else {
+            enumerate_whisper_gpu_devices()
+        }
     })
 }
 
@@ -1970,28 +2107,38 @@ static TRANSCRIBE_CPP_DEVICES: OnceLock<Vec<GpuDeviceOption>> = OnceLock::new();
 
 fn cached_transcribe_cpp_devices() -> &'static [GpuDeviceOption] {
     TRANSCRIBE_CPP_DEVICES.get_or_init(|| {
-        // Same FMA3 guard as the whisper GPU probe: ggml's Vulkan backend uses
-        // FMA3, which SIGILLs on CPUs without it; skip enumeration there.
-        #[cfg(target_arch = "x86_64")]
-        if !std::arch::is_x86_feature_detected!("fma") {
-            warn!("CPU lacks FMA3 support — skipping transcribe.cpp device enumeration");
-            return Vec::new();
+        if PROBE_DEVICES_OUT_OF_PROCESS {
+            device_probe().transcribe_cpp.clone()
+        } else {
+            enumerate_transcribe_cpp_devices()
         }
-
-        transcribe_cpp::devices()
-            .into_iter()
-            .map(|d| GpuDeviceOption {
-                id: d.index.map(|i| i as i32).unwrap_or(-1),
-                name: if d.description.is_empty() {
-                    d.name
-                } else {
-                    d.description
-                },
-                kind: "unknown".to_string(),
-                total_vram_mb: (d.memory_total / (1024 * 1024)) as usize,
-            })
-            .collect()
     })
+}
+
+/// Enumerate the transcribe.cpp compute devices in THIS process. Requires
+/// `init_transcribe_cpp()` (backend modules) to have run first.
+fn enumerate_transcribe_cpp_devices() -> Vec<GpuDeviceOption> {
+    // Same FMA3 guard as the whisper GPU probe: ggml's Vulkan backend uses
+    // FMA3, which SIGILLs on CPUs without it; skip enumeration there.
+    #[cfg(target_arch = "x86_64")]
+    if !std::arch::is_x86_feature_detected!("fma") {
+        warn!("CPU lacks FMA3 support — skipping transcribe.cpp device enumeration");
+        return Vec::new();
+    }
+
+    transcribe_cpp::devices()
+        .into_iter()
+        .map(|d| GpuDeviceOption {
+            id: d.index.map(|i| i as i32).unwrap_or(-1),
+            name: if d.description.is_empty() {
+                d.name
+            } else {
+                d.description
+            },
+            kind: "unknown".to_string(),
+            total_vram_mb: (d.memory_total / (1024 * 1024)) as usize,
+        })
+        .collect()
 }
 
 /// Return which accelerators are compiled into this build.
@@ -2049,6 +2196,56 @@ impl Drop for TranscriptionManager {
 mod tests {
     use super::*;
     use transcribe_cpp::{Capabilities, Task, TimestampKind};
+
+    /// The child's device list must survive a round trip through stdout, and any
+    /// log noise it printed first must be ignored. This is what stands between a
+    /// crashed/chatty probe and a GPU list, so it is worth pinning.
+    #[test]
+    fn device_probe_output_parses_past_leading_log_noise() {
+        let probe = DeviceProbe {
+            whisper: vec![GpuDeviceOption {
+                id: 0,
+                name: "Test GPU".to_string(),
+                kind: "dedicated".to_string(),
+                total_vram_mb: 8192,
+            }],
+            transcribe_cpp: vec![GpuDeviceOption {
+                id: -1,
+                name: "CPU".to_string(),
+                kind: "unknown".to_string(),
+                total_vram_mb: 0,
+            }],
+        };
+        let stdout = format!(
+            "transcribe_init_backends: 1 compute device(s) registered\nsome driver warning\n{}\n",
+            serde_json::to_string(&probe).unwrap()
+        );
+
+        let parsed = parse_device_probe_output(&stdout).expect("probe output should parse");
+        assert_eq!(parsed.whisper.len(), 1);
+        assert_eq!(parsed.whisper[0].name, "Test GPU");
+        assert_eq!(parsed.whisper[0].total_vram_mb, 8192);
+        assert_eq!(parsed.transcribe_cpp.len(), 1);
+        assert_eq!(parsed.transcribe_cpp[0].name, "CPU");
+    }
+
+    /// A probe that cannot even be launched must return an error, so the caller
+    /// falls back to CPU-only instead of panicking. The whole point of the child
+    /// process is that its failure is survivable.
+    #[test]
+    fn device_probe_with_unlaunchable_binary_returns_error() {
+        let missing = std::env::temp_dir().join("speakoflow_probe_does_not_exist_xyz");
+        assert!(probe_devices_via(&missing).is_err());
+    }
+
+    /// A probe that died before printing anything (the SIGILL case) must surface
+    /// as an error so the caller degrades to CPU-only instead of hanging or
+    /// panicking.
+    #[test]
+    fn device_probe_output_without_json_is_an_error() {
+        assert!(parse_device_probe_output("").is_err());
+        assert!(parse_device_probe_output("Illegal instruction (core dumped)\n").is_err());
+    }
 
     /// A stalled/behind worker (the receiver is held, nothing is consumed) must
     /// never let the live-transcription feed queue grow past the cap: excess


### PR DESCRIPTION
Same two fixes as #10, rebased onto main so they land on the default branch.

**1. Gemini tool calls die after the first round (fixes #9)**

Gemini's thinking models return an opaque, encrypted `thought_signature` with every function call and reject the follow-up request unless it is echoed back verbatim (`400 INVALID_ARGUMENT: Function call is missing a thought_signature in functionCall parts`). Our SSE decoder ignored `tool_calls[].extra_content`, so the signature never survived to the next round and any tool use on Gemini failed. Same gap hit openai/codex#7519 and JetBrains' Koog, so it is a general OpenAI-compat pitfall.

`llm_client.rs` now captures `extra_content.google.thought_signature` and merges it by tool-call index (Gemini may send it on a later frame); `assistant.rs` re-attaches it when rebuilding the assistant message. Added only when the provider sent one, so requests to every other provider are byte-identical.

**2. Linux launch crash: SIGILL in GPU device enumeration**

Reported downstream while packaging for AUR: the AppImage dies at startup with `illegal hardware instruction (core dumped)` just after the tray initializes. `whisper-rs-sys` sets no `GGML_NATIVE`, so ggml's default `GGML_NATIVE=ON` applies and its static whisper.cpp/ggml is compiled with `-march=native`. Loading its Vulkan backend on a narrower CPU than the build machine raises an uncatchable SIGILL, on the startup pre-warm thread, so the app dies before any window appears. `transcribe-cpp` is immune (`GGML_NATIVE=OFF` + `GGML_CPU_ALL_VARIANTS`); the older stack is not, and the existing FMA3 guard only covers one instruction family.

On Linux, enumeration now runs in a short-lived child (`self --probe-devices`, one JSON line). A crash, a hang on a broken Vulkan driver, or a failed spawn logs a warning and reports no GPU, and the app still starts and transcribes on CPU. Windows and macOS keep the in-process call; the branch is a `cfg!` const so both paths stay compiled and type-checked everywhere while the dead one folds away.

Deliberately not addressed: the underlying `-march=native` build (needs a patched `whisper-rs-sys`; the crash should be survivable regardless), and the ubuntu-24.04 AppImage runner.

## Test plan

- `cargo test --lib`: 282 passed, 0 failed. New tests cover signature capture from a later frame, no-signature staying `None`, probe output parsed past log noise, missing JSON as an error, and an unlaunchable probe returning `Err` instead of panicking.
- `cargo check` clean, `cargo clippy --lib` adds no new warnings.
- Child probe exercised for real on Windows: `--probe-devices` exits 0 and prints valid single-line JSON for both GPUs and the CPU device.

Not verified locally: the Linux parent path (needs a Linux build) and the Gemini round trip against the live API (needs a key).

## AI assistance

Written with AI assistance (Kiro). Diagnosis, code and tests reviewed by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved GPU device detection on Linux for greater startup reliability and resilience on unsupported hardware.
  * Added machine-readable device probing for faster, safer hardware enumeration.
  * Preserved tool-call context during streamed AI interactions, improving compatibility with supported models.
* **Documentation**
  * Expanded technical documentation for device detection behavior and hardware compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->