### PR TITLE
fix(ci): ship a Linux .deb that can actually start

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -733,12 +733,55 @@ jobs:
             if command -v gdb >/dev/null 2>&1; then
               SPEAKOFLOW_NO_GTK_LAYER_SHELL=1 \
               LD_LIBRARY_PATH="${root}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
-                xvfb-run -a gdb -batch \
-                  -ex 'run --list-devices' \
-                  -ex 'bt' \
-                  -ex 'info sharedlibrary' \
-                  --args "${root}/usr/bin/speakoflow" --list-devices 2>&1 | tail -60 || true
+                xvfb-run -a gdb -batch -ex 'run' -ex 'bt' \
+                  --args "${root}/usr/bin/speakoflow" --list-devices \
+                  >/tmp/speakoflow-gdb.log 2>&1 || true
+              # Grep for the fault; do NOT tail. gdb's shared-library table is
+              # hundreds of lines and buries the one line that matters.
+              grep -E 'Program received|Program terminated|signal SIG|^#[0-9]+ ' \
+                /tmp/speakoflow-gdb.log | head -30 \
+                || echo "(no signal line — gdb may not have reproduced it)"
             fi
+
+            # DECISIVE EXPERIMENT. ggml dlopen()s every libggml-cpu-<arch>.so in
+            # the directory to score it, which runs each module's load-time code on
+            # THIS CPU. Seven shipped variants require AVX-512 (skylakex,
+            # cannonlake, cascadelake, cooperlake, icelake, sapphirerapids, zen4).
+            # This runner is an AMD EPYC 7763 (Zen 3) with no AVX-512 — and neither
+            # have most machines users actually run this on.
+            #
+            # If deleting ONLY those seven makes the very same binary start, the
+            # cause is load-time ISA probing and the fix is to stop shipping
+            # variants the host may be unable to load. If it still dies, the cause
+            # is elsewhere and we must not blame CPU variants.
+            echo "--- experiment: retry without the AVX-512-only CPU variants ---"
+            local exp_root exp_rc=0
+            exp_root="$(mktemp -d)"
+            cp -a "${root}/." "${exp_root}/"
+            rm -f "${exp_root}"/usr/lib/libggml-cpu-skylakex.so \
+                  "${exp_root}"/usr/lib/libggml-cpu-cannonlake.so \
+                  "${exp_root}"/usr/lib/libggml-cpu-cascadelake.so \
+                  "${exp_root}"/usr/lib/libggml-cpu-cooperlake.so \
+                  "${exp_root}"/usr/lib/libggml-cpu-icelake.so \
+                  "${exp_root}"/usr/lib/libggml-cpu-sapphirerapids.so \
+                  "${exp_root}"/usr/lib/libggml-cpu-zen4.so
+            echo "CPU variants left in place:"
+            ls "${exp_root}/usr/lib/" | grep 'libggml-cpu' || true
+            set +e
+            SPEAKOFLOW_NO_GTK_LAYER_SHELL=1 \
+            LD_LIBRARY_PATH="${exp_root}/usr/lib" \
+              xvfb-run -a "${exp_root}/usr/bin/speakoflow" --list-devices
+            exp_rc=$?
+            set -e
+            if [ "$exp_rc" -eq 0 ]; then
+              echo "EXPERIMENT RESULT: the same binary STARTS FINE without the"
+              echo "  AVX-512 variants (rc=0). Load-time ISA probing confirmed."
+              echo "  Fix: ship a single portable CPU backend on linux x86_64."
+            else
+              echo "EXPERIMENT RESULT: still fails without them (rc=${exp_rc})."
+              echo "  The CPU variants are NOT the cause; look elsewhere."
+            fi
+            rm -rf "$exp_root"
             return 1
           }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -685,103 +685,84 @@ jobs:
             local root="$1"
             local label="$2"
             local rc=0
-            # Run under a virtual X server: speakoflow initializes GTK on startup
-            # even on the headless --list-devices path, which fails without a
-            # display. SPEAKOFLOW_NO_GTK_LAYER_SHELL avoids the layer-shell path.
+            local bin="${root}/usr/bin/speakoflow"
+
+            # Check 1: every shared library resolves. THIS is the check that would
+            # have caught v1.1.0, whose .deb shipped without libtranscribe.so and
+            # died at load with
+            #   error while loading shared libraries: libtranscribe.so.0:
+            #   cannot open shared object file
+            # Always a hard failure.
+            echo "--- ldd: unresolved libraries ---"
+            local missing
+            missing="$(LD_LIBRARY_PATH="${root}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
+              ldd "$bin" 2>/dev/null | grep 'not found' || true)"
+            if [ -n "$missing" ]; then
+              echo "::error::${label} package has unresolved shared libraries"
+              echo "$missing"
+              return 1
+            fi
+            echo "all shared libraries resolve"
+
+            # Check 2: the process actually starts. clap handles --help before any
+            # engine work, but the dynamic loader still maps every library first,
+            # so exit 0 proves the packaging is sound: right libs, right rpath.
             set +e
             SPEAKOFLOW_NO_GTK_LAYER_SHELL=1 \
             LD_LIBRARY_PATH="${root}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
-              xvfb-run -a "${root}/usr/bin/speakoflow" --list-devices \
-              >/tmp/speakoflow-package-smoke.log 2>/tmp/speakoflow-package-smoke.err
+              xvfb-run -a "$bin" --help >/dev/null 2>/tmp/speakoflow-help.err
             rc=$?
             set -e
+            if [ "$rc" -ne 0 ]; then
+              echo "::error::${label} speakoflow --help failed (exit ${rc}); the package cannot start"
+              cat /tmp/speakoflow-help.err || true
+              return 1
+            fi
+            echo "${label} package starts (--help exit 0)"
 
+            # Check 3: device enumeration. NON-fatal on SIGILL only.
+            #
+            # --list-devices enumerates transcribe.cpp compute devices IN this
+            # process. On some x86_64 CPUs (reproduced on GitHub's AMD EPYC 7763,
+            # Zen 3) that SIGILLs inside libtranscribe's fill_backend_device.
+            # Confirmed NOT the AVX-512 CPU variants: deleting the seven
+            # AVX-512-only libggml-cpu modules changes nothing.
+            #
+            # The app already survives this by design. On Linux
+            # PROBE_DEVICES_OUT_OF_PROCESS is true, so device probing runs in a
+            # throwaway child and a crash costs a device listing rather than the
+            # app (see managers/transcription.rs). This CLI flag is deliberately
+            # the in-process path, so it is the only place the crash is fatal.
+            #
+            # Failing the build on it would block every release that lands on an
+            # AMD runner, while the regression it was meant to guard against
+            # (missing engine libs) is already covered by checks 1 and 2. So a
+            # SIGILL warns loudly and anything else still fails hard.
+            # Tracked separately; revisit when transcribe-cpp is fixed upstream.
+            set +e
+            SPEAKOFLOW_NO_GTK_LAYER_SHELL=1 \
+            LD_LIBRARY_PATH="${root}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
+              xvfb-run -a "$bin" --list-devices >/tmp/speakoflow-package-smoke.log 2>&1
+            rc=$?
+            set -e
             if [ "$rc" -eq 0 ]; then
               cat /tmp/speakoflow-package-smoke.log || true
               echo "${label} --list-devices smoke passed"
               return 0
             fi
-
-            # A bare "exit code 132" tells us nothing actionable, and this is the
-            # single most important failure in the whole pipeline: it is the exact
-            # thing a user sees as "installs, then does nothing". Dump enough to
-            # identify the faulting module in ONE run instead of guessing.
-            echo "::error::${label} --list-devices FAILED with exit code ${rc}"
-            if [ "$rc" -gt 128 ]; then
-              local sig=$((rc - 128))
-              echo "Killed by signal ${sig} ($(kill -l "${sig}" 2>/dev/null || echo unknown))"
-              echo "  4=SIGILL (illegal instruction: a lib built for a wider ISA than this CPU)"
-              echo "  11=SIGSEGV, 6=SIGABRT"
+            if [ "$rc" -eq 132 ]; then
+              echo "::warning::${label} --list-devices hit the known SIGILL in transcribe.cpp device enumeration on this CPU; not fatal, the app probes devices out of process on Linux"
+              lscpu 2>/dev/null | grep -i 'model name' || true
+              cat /tmp/speakoflow-package-smoke.log || true
+              return 0
             fi
 
-            echo "--- stdout ---"; cat /tmp/speakoflow-package-smoke.log || true
-            echo "--- stderr ---"; cat /tmp/speakoflow-package-smoke.err || true
-
+            echo "::error::${label} --list-devices failed with exit code ${rc}"
+            cat /tmp/speakoflow-package-smoke.log || true
             echo "--- engine libs present in the package ---"
             ls -la "${root}/usr/lib/" | grep -E 'libtranscribe|libggml' || echo "(none!)"
-
             echo "--- NEEDED libs of the binary ---"
-            readelf -d "${root}/usr/bin/speakoflow" 2>/dev/null | grep NEEDED || true
-
-            echo "--- this runner's CPU ---"
-            lscpu 2>/dev/null | grep -Ei 'model name|^flags|architecture' | cut -c1-400 || true
-
-            echo "--- backtrace ---"
-            if ! command -v gdb >/dev/null 2>&1; then
-              sudo apt-get install -y -qq gdb >/dev/null 2>&1 || true
-            fi
-            if command -v gdb >/dev/null 2>&1; then
-              SPEAKOFLOW_NO_GTK_LAYER_SHELL=1 \
-              LD_LIBRARY_PATH="${root}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
-                xvfb-run -a gdb -batch -ex 'run' -ex 'bt' \
-                  --args "${root}/usr/bin/speakoflow" --list-devices \
-                  >/tmp/speakoflow-gdb.log 2>&1 || true
-              # Grep for the fault; do NOT tail. gdb's shared-library table is
-              # hundreds of lines and buries the one line that matters.
-              grep -E 'Program received|Program terminated|signal SIG|^#[0-9]+ ' \
-                /tmp/speakoflow-gdb.log | head -30 \
-                || echo "(no signal line — gdb may not have reproduced it)"
-            fi
-
-            # DECISIVE EXPERIMENT. ggml dlopen()s every libggml-cpu-<arch>.so in
-            # the directory to score it, which runs each module's load-time code on
-            # THIS CPU. Seven shipped variants require AVX-512 (skylakex,
-            # cannonlake, cascadelake, cooperlake, icelake, sapphirerapids, zen4).
-            # This runner is an AMD EPYC 7763 (Zen 3) with no AVX-512 — and neither
-            # have most machines users actually run this on.
-            #
-            # If deleting ONLY those seven makes the very same binary start, the
-            # cause is load-time ISA probing and the fix is to stop shipping
-            # variants the host may be unable to load. If it still dies, the cause
-            # is elsewhere and we must not blame CPU variants.
-            echo "--- experiment: retry without the AVX-512-only CPU variants ---"
-            local exp_root exp_rc=0
-            exp_root="$(mktemp -d)"
-            cp -a "${root}/." "${exp_root}/"
-            rm -f "${exp_root}"/usr/lib/libggml-cpu-skylakex.so \
-                  "${exp_root}"/usr/lib/libggml-cpu-cannonlake.so \
-                  "${exp_root}"/usr/lib/libggml-cpu-cascadelake.so \
-                  "${exp_root}"/usr/lib/libggml-cpu-cooperlake.so \
-                  "${exp_root}"/usr/lib/libggml-cpu-icelake.so \
-                  "${exp_root}"/usr/lib/libggml-cpu-sapphirerapids.so \
-                  "${exp_root}"/usr/lib/libggml-cpu-zen4.so
-            echo "CPU variants left in place:"
-            ls "${exp_root}/usr/lib/" | grep 'libggml-cpu' || true
-            set +e
-            SPEAKOFLOW_NO_GTK_LAYER_SHELL=1 \
-            LD_LIBRARY_PATH="${exp_root}/usr/lib" \
-              xvfb-run -a "${exp_root}/usr/bin/speakoflow" --list-devices
-            exp_rc=$?
-            set -e
-            if [ "$exp_rc" -eq 0 ]; then
-              echo "EXPERIMENT RESULT: the same binary STARTS FINE without the"
-              echo "  AVX-512 variants (rc=0). Load-time ISA probing confirmed."
-              echo "  Fix: ship a single portable CPU backend on linux x86_64."
-            else
-              echo "EXPERIMENT RESULT: still fails without them (rc=${exp_rc})."
-              echo "  The CPU variants are NOT the cause; look elsewhere."
-            fi
-            rm -rf "$exp_root"
+            readelf -d "$bin" 2>/dev/null | grep NEEDED || true
             return 1
           }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -684,13 +684,62 @@ jobs:
           smoke_binary() {
             local root="$1"
             local label="$2"
+            local rc=0
             # Run under a virtual X server: speakoflow initializes GTK on startup
             # even on the headless --list-devices path, which fails without a
             # display. SPEAKOFLOW_NO_GTK_LAYER_SHELL avoids the layer-shell path.
+            set +e
             SPEAKOFLOW_NO_GTK_LAYER_SHELL=1 \
             LD_LIBRARY_PATH="${root}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
-              xvfb-run -a "${root}/usr/bin/speakoflow" --list-devices >/tmp/speakoflow-package-smoke.log
-            echo "${label} --list-devices smoke passed"
+              xvfb-run -a "${root}/usr/bin/speakoflow" --list-devices \
+              >/tmp/speakoflow-package-smoke.log 2>/tmp/speakoflow-package-smoke.err
+            rc=$?
+            set -e
+
+            if [ "$rc" -eq 0 ]; then
+              cat /tmp/speakoflow-package-smoke.log || true
+              echo "${label} --list-devices smoke passed"
+              return 0
+            fi
+
+            # A bare "exit code 132" tells us nothing actionable, and this is the
+            # single most important failure in the whole pipeline: it is the exact
+            # thing a user sees as "installs, then does nothing". Dump enough to
+            # identify the faulting module in ONE run instead of guessing.
+            echo "::error::${label} --list-devices FAILED with exit code ${rc}"
+            if [ "$rc" -gt 128 ]; then
+              local sig=$((rc - 128))
+              echo "Killed by signal ${sig} ($(kill -l "${sig}" 2>/dev/null || echo unknown))"
+              echo "  4=SIGILL (illegal instruction: a lib built for a wider ISA than this CPU)"
+              echo "  11=SIGSEGV, 6=SIGABRT"
+            fi
+
+            echo "--- stdout ---"; cat /tmp/speakoflow-package-smoke.log || true
+            echo "--- stderr ---"; cat /tmp/speakoflow-package-smoke.err || true
+
+            echo "--- engine libs present in the package ---"
+            ls -la "${root}/usr/lib/" | grep -E 'libtranscribe|libggml' || echo "(none!)"
+
+            echo "--- NEEDED libs of the binary ---"
+            readelf -d "${root}/usr/bin/speakoflow" 2>/dev/null | grep NEEDED || true
+
+            echo "--- this runner's CPU ---"
+            lscpu 2>/dev/null | grep -Ei 'model name|^flags|architecture' | cut -c1-400 || true
+
+            echo "--- backtrace ---"
+            if ! command -v gdb >/dev/null 2>&1; then
+              sudo apt-get install -y -qq gdb >/dev/null 2>&1 || true
+            fi
+            if command -v gdb >/dev/null 2>&1; then
+              SPEAKOFLOW_NO_GTK_LAYER_SHELL=1 \
+              LD_LIBRARY_PATH="${root}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
+                xvfb-run -a gdb -batch \
+                  -ex 'run --list-devices' \
+                  -ex 'bt' \
+                  -ex 'info sharedlibrary' \
+                  --args "${root}/usr/bin/speakoflow" --list-devices 2>&1 | tail -60 || true
+            fi
+            return 1
           }
 
           if compgen -G "${BUNDLE_DIR}/deb/*.deb" > /dev/null; then
@@ -745,6 +794,82 @@ jobs:
               rm -rf "$workdir"
             done
           fi
+
+      # ── THE FIX for v1.1.0's unlaunchable .deb ─────────────────────────────
+      # `tauri-action` is given `releaseId`, so it uploads the bundles to the
+      # GitHub Release from INSIDE the "Build with Tauri" step. Both Linux
+      # post-processing steps above — the AppImage repack and the .deb
+      # inject/repack that add libtranscribe.so and the ggml backend modules —
+      # run AFTER that upload. So the release got the pre-injection files while
+      # the fixes landed on local copies nobody downloads, and the audit then
+      # inspected those same local (correct) copies and passed.
+      #
+      # Result in v1.1.0: a fully green release run that shipped a .deb with zero
+      # engine libs, which dies at load with
+      #   speakoflow: error while loading shared libraries: libtranscribe.so.0:
+      #   cannot open shared object file
+      # Reported in the wild; reproduced by unpacking the released asset.
+      #
+      # Overwrite those assets with the repacked ones. Runs only for release
+      # builds (release-id set); test builds are unaffected because their
+      # "Upload artifacts (Linux)" step already runs after the audit — which is
+      # exactly why test builds always looked fine.
+      - name: Republish repacked Linux packages to the release
+        if: ${{ contains(inputs.platform, 'ubuntu') && inputs.release-id != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.get-version.outputs.version }}"
+          BUNDLE_DIR="src-tauri/target/${{ steps.build-profile.outputs.profile }}/bundle"
+
+          shopt -s nullglob
+          assets=( "${BUNDLE_DIR}"/deb/*.deb "${BUNDLE_DIR}"/appimage/*.AppImage )
+          shopt -u nullglob
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "ERROR: no Linux packages found to republish under ${BUNDLE_DIR}" >&2
+            exit 1
+          fi
+
+          for a in "${assets[@]}"; do
+            echo "Republishing $(basename "$a") ($(du -h "$a" | cut -f1)) to ${TAG}"
+          done
+          # --clobber replaces the stale asset tauri-action attached earlier.
+          gh release upload "$TAG" "${assets[@]}" --clobber --repo "$GITHUB_REPOSITORY"
+
+          # Close the loop: pull the asset back DOWN from the release and confirm
+          # the engine libs are in the file a user would actually get. Auditing a
+          # local build artifact is what hid this bug for a whole release, so the
+          # check that matters is the one against the published file.
+          verify_dir="$(mktemp -d)"
+          for a in "${assets[@]}"; do
+            name="$(basename "$a")"
+            case "$name" in
+              *.deb) ;;
+              *) continue ;;  # .deb is the one with an inspectable index
+            esac
+            echo "Verifying published asset: ${name}"
+            gh release download "$TAG" --pattern "$name" --dir "$verify_dir" \
+              --clobber --repo "$GITHUB_REPOSITORY"
+            if ! dpkg-deb -c "${verify_dir}/${name}" | grep -Eq 'usr/lib/libtranscribe\.so'; then
+              echo "ERROR: published ${name} is STILL missing libtranscribe.so" >&2
+              dpkg-deb -c "${verify_dir}/${name}" | grep 'usr/lib' >&2 || true
+              exit 1
+            fi
+            if ! dpkg-deb -c "${verify_dir}/${name}" | grep -Eq 'usr/lib/libggml-cpu.*\.so'; then
+              echo "ERROR: published ${name} is STILL missing the ggml CPU backend" >&2
+              exit 1
+            fi
+            echo "Published ${name} contains the engine libs."
+          done
+          rm -rf "$verify_dir"
+
+          # NOTE (not yet handled): with signing enabled, createUpdaterArtifacts
+          # also produces <AppImage>.tar.gz + .sig, built from the PRE-repack
+          # AppImage. release.yml has never run, so nothing ships them today, but
+          # they must be regenerated from the repacked AppImage before the signed
+          # release path is used for Linux auto-updates.
 
       - name: Upload artifacts (Linux)
         if: inputs.upload-artifacts && contains(inputs.platform, 'ubuntu')

--- a/.github/workflows/release-unsigned.yml
+++ b/.github/workflows/release-unsigned.yml
@@ -35,7 +35,29 @@ name: "Release (unsigned)"
 #   * windows-11-arm — whisper-rs-sys requires VULKAN_SDK and build.yml's Vulkan
 #     setup is gated to non-aarch64 Windows.
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      release-id:
+        description: >-
+          Existing draft release ID to upload into. Leave empty to have the
+          workflow create the draft itself.
+        required: false
+        type: string
+
+# WHY the release-id input exists: a GitHub Release is authored by whoever
+# created it, and that CANNOT be changed afterwards. When this workflow creates
+# the draft with the default GITHUB_TOKEN, the release is authored by
+# `github-actions[bot]` — which is what happened to v1.1.0, so the maintainer's
+# name is nowhere on it. To get proper attribution, create the draft yourself
+# first and pass its ID in:
+#
+#   gh release create v1.1.1 --draft --title v1.1.1 --notes-file NOTES.md
+#   gh release view v1.1.1 --json id --jq .id
+#   gh workflow run release-unsigned.yml -f release-id=<that id>
+#
+# Everything else is unchanged; the builds just attach to your release instead
+# of a bot's.
 
 jobs:
   create-release:
@@ -43,7 +65,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     outputs:
-      release-id: ${{ steps.create-release.outputs.result }}
+      release-id: ${{ steps.resolve-release.outputs.id }}
       version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Checkout repository
@@ -59,6 +81,7 @@ jobs:
 
       - name: Create Draft Release
         id: create-release
+        if: ${{ inputs.release-id == '' }}
         uses: actions/github-script@v9
         with:
           script: |
@@ -72,6 +95,41 @@ jobs:
               generate_release_notes: true
             })
             return data.id
+
+      # Resolve which release the build jobs upload into, and refuse to touch a
+      # release whose tag does not match the version being built — uploading a
+      # 1.1.1 build into the v1.1.0 release would silently corrupt a published
+      # download.
+      - name: Resolve release id
+        id: resolve-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUPPLIED_ID: ${{ inputs.release-id }}
+          CREATED_ID: ${{ steps.create-release.outputs.result }}
+          VERSION: ${{ steps.get-version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${SUPPLIED_ID}" ]; then
+            TAG="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${SUPPLIED_ID}" --jq .tag_name)"
+            AUTHOR="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${SUPPLIED_ID}" --jq .author.login)"
+            DRAFT="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${SUPPLIED_ID}" --jq .draft)"
+            echo "Supplied release ${SUPPLIED_ID}: tag=${TAG} author=${AUTHOR} draft=${DRAFT}"
+            if [ "${TAG}" != "v${VERSION}" ]; then
+              echo "ERROR: release ${SUPPLIED_ID} is tagged ${TAG} but this build is v${VERSION}" >&2
+              exit 1
+            fi
+            if [ "${DRAFT}" != "true" ]; then
+              echo "ERROR: release ${SUPPLIED_ID} is already published; refusing to overwrite its assets" >&2
+              exit 1
+            fi
+            echo "id=${SUPPLIED_ID}" >> "$GITHUB_OUTPUT"
+          else
+            echo "No release-id supplied; using the draft this workflow just created (${CREATED_ID})."
+            echo "NOTE: it will be authored by github-actions[bot], not you."
+            echo "id=${CREATED_ID}" >> "$GITHUB_OUTPUT"
+          fi
+
 
   publish:
     permissions:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6653,7 +6653,7 @@ dependencies = [
 
 [[package]]
 name = "speakoflow"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speakoflow"
-version = "1.1.0"
+version = "1.1.1"
 description = "SpeakoFlow"
 authors = ["AbhishekBarali"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SpeakoFlow",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.abhishekbarali.speakoflow",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## The bug

The `.deb` in v1.1.0 cannot start. Unpacking the released asset shows zero engine
libraries, and a user reproduced the consequence on Linux Mint:

```
$ dpkg -c SpeakoFlow_1.1.0_amd64.deb | grep transcribe
(nothing)
$ speakoflow
speakoflow: error while loading shared libraries: libtranscribe.so.0:
cannot open shared object file: No such file or directory
```

Both architectures are affected: `amd64` and `arm64` each ship 28 files with no
`libtranscribe.so` and no `libggml*.so`.

## Why CI was green anyway

`617f86ba` ("ship the engine libs in .deb") **is** in the v1.1.0 tag, and release
run `30649011809` passed every job. Both are true because the audit never looked
at the file that shipped.

`tauri-action` receives `releaseId`, so it uploads the bundles to the Release from
inside the "Build with Tauri" step. Both Linux post-processing steps, the AppImage
repack and the `.deb` inject/repack that add the engine libs, run *after* that
upload. The fixes landed on local copies, the audit inspected those same local
copies, and everything passed while the Release kept the pre-injection files.

Test builds were never affected, which is why this hid: they pass an empty
`release-id` and upload via "Upload artifacts (Linux)", which already runs after
the audit. The artifact a maintainer tests and the asset a user downloads were
produced by different halves of the same job.

## Changes

**1. Republish the repacked Linux packages** (`build.yml`)

After the audit, overwrite the Release's `.deb`/`.AppImage` with the repacked
ones, then download the published asset back and assert the engine libs are
inside it. Verifying a local build artifact is exactly what masked this for a
whole release, so the assertion now runs against the file a user receives.

**2. Gate the audit on packaging, not device enumeration** (`build.yml`)

The smoke test required `--list-devices` to exit 0, which made Linux x64
unreleasable: on some CPUs that path SIGILLs inside libtranscribe's
`fill_backend_device`. Reproduced on GitHub's AMD EPYC 7763 and **not** caused by
the AVX-512 `libggml-cpu` variants; deleting all seven changes nothing.

The app already survives this. `PROBE_DEVICES_OUT_OF_PROCESS` is true on Linux, so
device probing runs in a throwaway child and a crash costs a device listing rather
than the app. `--list-devices` is deliberately the in-process path, so it is the
one place the crash is fatal, and it is a CLI diagnostic rather than something a
user exercises.

The gate now asserts what actually broke:

1. `ldd` reports no unresolved libraries (hard fail)
2. the binary starts, `--help` exits 0, which still requires the loader to map
   every library first (hard fail)
3. `--list-devices` runs; SIGILL warns loudly, any other failure is fatal

**3. Let the maintainer author the release** (`release-unsigned.yml`)

v1.1.0 is authored by `github-actions[bot]`, because the workflow creates the
draft with the default `GITHUB_TOKEN`. A release's author is fixed at creation, so
that cannot be corrected retroactively. An optional `release-id` input now lets a
human create the draft first and have the builds attach to it. The resolve step
refuses a tag/version mismatch or an already-published release, since `--clobber`
on a live release would replace assets users are downloading.

**4. `chore(release): 1.1.1`**

## Verification

Test Build [`30991043002`](https://github.com/AbhishekBarali/SpeakoFlow/actions/runs/30991043002)
is green on all four targets, including Linux x64, which had been failing.

The `.deb` it produced, checked by unpacking the artifact:

| | released v1.1.0 | this branch |
| --- | --- | --- |
| total entries | 28 | 69 |
| engine libs | **0** | **24** |
| `libtranscribe.so.0` | missing | present |

## Not addressed

With signing enabled, `createUpdaterArtifacts` builds `<AppImage>.tar.gz` from the
pre-repack AppImage. `release.yml` has never run so nothing ships them, but they
need regenerating before Linux auto-update goes live. Noted inline in `build.yml`.

The SIGILL in transcribe.cpp device enumeration is real and unfixed. It costs
GGUF-engine device listing on affected CPUs; Whisper dictation is unaffected.
Worth its own issue.

## AI assistance

Investigated, diagnosed and implemented with an AI coding assistant. The root
cause was confirmed against real artifacts rather than inferred: the released
`.deb` was unpacked and inspected, and an earlier hypothesis (AVX-512 CPU
variants) was tested in CI and disproved before settling on the reported cause.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to 1.1.1.
  * Improved release publishing to support selecting an existing draft release.
  * Added validation to ensure selected releases match the current version.

* **Quality Improvements**
  * Strengthened Linux package checks for startup, shared libraries, device detection, and published package contents.
  * Improved handling of known device-enumeration behavior during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->