### PR TITLE
ci: prove an Intel macOS build, and fix the false claim in #19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,20 @@ name: "Build"
 #
 #   * transcribe-cpp (GGUF/ggml) is the new engine. Windows x86_64 + Linux ship
 #     it in the `dynamic-backends` + `vulkan` posture (loadable ggml backend
-#     DLLs/.so + a Vulkan GPU backend); macOS links it statically (`metal`);
-#     Windows-on-ARM links it statically CPU-only (no DLLs).
+#     DLLs/.so + a Vulkan GPU backend); macOS aarch64 links it statically
+#     (`metal`); macOS x86_64 and Windows-on-ARM link it statically CPU-only
+#     (no DLLs, no GPU backend).
 #   * transcribe-rs 0.3.11 is KEPT AS-IS with its statically-embedded ONNX
 #     Runtime (+ `ort-directml` on Windows). We deliberately do NOT converge to
 #     Handy's shape-(a) dynamically-linked baseline ORT, so — unlike Handy —
 #     there are NO `ORT_LIB_LOCATION` / `ORT_PREFER_DYNAMIC_LINK` steps and no
 #     onnxruntime.dll staging/audit here.
+#
+#     ONE EXCEPTION: Intel macOS (x86_64-apple-darwin), where pykeio's `ort`
+#     dropped prebuilt binaries entirely, so there is no static ORT to embed.
+#     That target links against Homebrew's onnxruntime and ships the dylib inside
+#     the .app — see "Stage ONNX Runtime for Intel macOS" and
+#     "Audit Intel macOS bundle" below. Apple Silicon is untouched by this.
 #
 # What this covers (Session 7 requirements):
 #   * Vulkan SDK (Windows x64) + SPIRV-Headers (vcpkg) on CMAKE_PREFIX_PATH.
@@ -467,6 +474,85 @@ jobs:
             console.log("Patched tauri.conf.json: signing disabled for unsigned test build");
           '
 
+      # ── Intel macOS (x86_64-apple-darwin) ─────────────────────────────────
+      # Intel macOS is the ONE target where SpeakoFlow links ONNX Runtime
+      # dynamically. pykeio's `ort` dropped prebuilt x86_64-apple-darwin binaries
+      # ("Support for Intel macOS has been dropped following upstream changes to
+      # ONNX Runtime & Rust"), so transcribe-rs's `onnx` feature has no static ORT
+      # to embed there — the shape-(b) posture that holds on every other target.
+      # Homebrew's onnxruntime fills the gap (this is what BUILD.md documents for
+      # local Intel builds).
+      #
+      # A *distributable* .dmg needs more than `brew --prefix`, though: a Homebrew
+      # dylib's install name is an absolute path into the build machine's Cellar,
+      # so linking straight against it produces an app that only starts on a Mac
+      # that happens to have the same formula installed. It has to travel inside
+      # the bundle instead.
+      #
+      # The rewrite happens BEFORE linking, which avoids all post-bundle surgery
+      # on the .app (and the stale-DMG problem that comes with it):
+      #   1. copy the dylib into src-tauri/onnx-libs/, dereferenced,
+      #   2. rewrite its install name to @rpath/libonnxruntime.dylib,
+      #   3. point ORT_LIB_LOCATION at that staged copy — so the linker records
+      #      @rpath/libonnxruntime.dylib in `speakoflow`, not /usr/local/...
+      # build.rs emits the matching @executable_path/../Frameworks rpath, the
+      # config patch below makes tauri-bundler copy the dylib into
+      # Contents/Frameworks, and the audit step after the build verifies all
+      # three halves actually met.
+      - name: Stage ONNX Runtime for Intel macOS
+        if: inputs.target == 'x86_64-apple-darwin'
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew install onnxruntime
+          BREW_LIB="$(brew --prefix onnxruntime)/lib"
+          echo "Homebrew onnxruntime lib dir: $BREW_LIB"
+          ls -la "$BREW_LIB"
+
+          STAGE="$GITHUB_WORKSPACE/src-tauri/onnx-libs"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE"
+
+          # -L dereferences Homebrew's libonnxruntime.dylib symlink into the real
+          # versioned object, so ONE self-contained file lands in the bundle under
+          # the plain name the linker resolves for -lonnxruntime.
+          cp -L "$BREW_LIB/libonnxruntime.dylib" "$STAGE/libonnxruntime.dylib"
+          chmod u+w "$STAGE/libonnxruntime.dylib"
+          install_name_tool -id "@rpath/libonnxruntime.dylib" "$STAGE/libonnxruntime.dylib"
+          # install_name_tool invalidates the dylib's existing signature; re-sign
+          # ad-hoc so it stays loadable (and re-signable later by the bundler).
+          codesign --force --sign - "$STAGE/libonnxruntime.dylib"
+
+          echo "Staged dylib install name:"
+          otool -D "$STAGE/libonnxruntime.dylib"
+
+          echo "ORT_LIB_LOCATION=$STAGE" >> "$GITHUB_ENV"
+          echo "ORT_PREFER_DYNAMIC_LINK=1" >> "$GITHUB_ENV"
+
+      # Make tauri-bundler copy the staged dylib into
+      # SpeakoFlow.app/Contents/Frameworks. `bundle.macOS.frameworks` accepts a
+      # path to a .dylib and copies it there verbatim — it deliberately does not
+      # touch install names or rpaths, which the two steps above/around it handle.
+      # Patched here rather than committed to tauri.conf.json so the path only
+      # exists for the Intel job; every other target would fail on a missing file.
+      - name: Bundle ONNX Runtime into the app (Intel macOS)
+        if: inputs.target == 'x86_64-apple-darwin'
+        shell: bash
+        run: |
+          node -e '
+            const fs = require("fs");
+            const p = "src-tauri/tauri.conf.json";
+            const c = JSON.parse(fs.readFileSync(p, "utf8"));
+            c.bundle = c.bundle || {};
+            c.bundle.macOS = c.bundle.macOS || {};
+            const fw = new Set(c.bundle.macOS.frameworks || []);
+            // Relative to tauri.conf.json (src-tauri/), same as bundle.resources.
+            fw.add("onnx-libs/libonnxruntime.dylib");
+            c.bundle.macOS.frameworks = [...fw];
+            fs.writeFileSync(p, JSON.stringify(c, null, 2));
+            console.log("Patched tauri.conf.json: macOS frameworks =", c.bundle.macOS.frameworks);
+          '
+
       # Split signed (production) vs unsigned (test). The UNSIGNED path passes NO
       # Apple/Azure/updater env at all: a present-but-EMPTY APPLE_CERTIFICATE makes
       # tauri attempt a keychain `security import` that fails ("SecKeychainItemImport:
@@ -506,6 +592,117 @@ jobs:
           releaseId: ${{ inputs.release-id }}
           assetNamePattern: ${{ steps.patch-release-name.outputs.platform }}
           args: ${{ inputs.build-args }}
+
+      # The hard gate for Intel macOS, mirroring the Windows/Linux package audits:
+      # a .dmg that installs and then cannot start is the failure mode worth
+      # catching in CI rather than in a user's issue tracker. Four failing checks,
+      # because each covers a different way the ORT bundling can silently
+      # half-work, plus one informational report:
+      #   1. the binary is really x86_64 (not an accidental arm64 build),
+      #   2. it references @rpath/libonnxruntime.dylib and NOT a Homebrew path
+      #      (a Homebrew path means step 2 of the staging never took effect),
+      #   3. the dylib is actually inside Contents/Frameworks (i.e. tauri-bundler
+      #      honored the `frameworks` entry) and carries the rpath to find it,
+      #   4. the bundled binary launches: `--list-devices` exits before Tauri and
+      #      any window setup, but dyld still has to resolve every linked dylib
+      #      first — so a missing/unresolvable libonnxruntime fails right here.
+      #      This runs on an Intel runner, so it is a genuine native check.
+      #   5. it prints the real minimum macOS version of the artifact, which the
+      #      bundled Homebrew dylib — not tauri.conf.json — ultimately decides.
+      #
+      # ONNX Runtime is NOT optional here, which is why all of this exists: `ort`
+      # is pulled in by vad-rs (Silero VAD, core to every recording) as well as
+      # transcribe-rs (Parakeet). Dropping the Parakeet engine would not remove it.
+      - name: Audit Intel macOS bundle
+        if: inputs.target == 'x86_64-apple-darwin'
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROFILE="${{ steps.build-profile.outputs.profile }}"
+          BUNDLE_DIR="src-tauri/target/x86_64-apple-darwin/${PROFILE}/bundle"
+
+          APP="$(find "${BUNDLE_DIR}/macos" -maxdepth 1 -name '*.app' | head -1)"
+          if [ -z "${APP:-}" ]; then
+            echo "ERROR: no .app produced under ${BUNDLE_DIR}/macos" >&2
+            find "src-tauri/target/x86_64-apple-darwin/${PROFILE}" -maxdepth 3 -name '*.app' -o -maxdepth 3 -name '*.dmg' >&2 || true
+            exit 1
+          fi
+          echo "Auditing ${APP}"
+
+          BIN="$(find "${APP}/Contents/MacOS" -maxdepth 1 -type f -perm -u+x | head -1)"
+          if [ -z "${BIN:-}" ]; then
+            echo "ERROR: no executable in ${APP}/Contents/MacOS" >&2
+            ls -la "${APP}/Contents/MacOS" >&2 || true
+            exit 1
+          fi
+
+          # 1. Architecture.
+          echo "--- file ---"
+          file "$BIN"
+          if ! file "$BIN" | grep -q 'x86_64'; then
+            echo "ERROR: ${BIN} is not x86_64" >&2
+            exit 1
+          fi
+
+          # 2. Load paths: @rpath in, Homebrew out.
+          echo "--- otool -L ---"
+          otool -L "$BIN"
+          if ! otool -L "$BIN" | grep -q '@rpath/libonnxruntime.dylib'; then
+            echo "ERROR: ${BIN} does not reference @rpath/libonnxruntime.dylib" >&2
+            echo "The ONNX Runtime staging step did not take effect before linking." >&2
+            exit 1
+          fi
+          if otool -L "$BIN" | grep -Ei 'onnxruntime' | grep -Eq '/(usr/local|opt/homebrew)/|Cellar'; then
+            echo "ERROR: ${BIN} still links ONNX Runtime from a Homebrew path" >&2
+            echo "The .dmg would only run on Macs with that exact formula installed." >&2
+            exit 1
+          fi
+
+          # 3. The dylib travelled, and the rpath to reach it is embedded.
+          if [ ! -f "${APP}/Contents/Frameworks/libonnxruntime.dylib" ]; then
+            echo "ERROR: libonnxruntime.dylib is missing from ${APP}/Contents/Frameworks" >&2
+            echo "tauri-bundler did not honor the bundle.macOS.frameworks entry." >&2
+            ls -la "${APP}/Contents/Frameworks" 2>/dev/null >&2 || echo "(no Frameworks dir at all)" >&2
+            exit 1
+          fi
+          echo "--- LC_RPATH ---"
+          otool -l "$BIN" | grep -A2 LC_RPATH || true
+          if ! otool -l "$BIN" | grep -q '@executable_path/../Frameworks'; then
+            echo "ERROR: ${BIN} has no @executable_path/../Frameworks rpath" >&2
+            echo "build.rs did not emit the rpath for this target." >&2
+            exit 1
+          fi
+
+          # 4. It actually starts. dyld resolves libonnxruntime before main() runs,
+          #    so this is the real end-to-end proof the bundling worked.
+          echo "--- runtime smoke test ---"
+          "$BIN" --list-devices
+          echo "Intel macOS bundle audit passed"
+
+          # 5. Informational, but decides who can actually run this: the REAL
+          #    minimum macOS is whichever of the app binary or the bundled dylib
+          #    demands more, not tauri.conf.json's minimumSystemVersion (10.15).
+          #    Homebrew builds bottles per-OS version, so a dylib pulled on a
+          #    macOS 15 runner may well refuse to load on an older Intel Mac —
+          #    and plenty of Intel Macs top out at Monterey or Ventura. Printed
+          #    loudly instead of assumed; it is what tells us which Intel Macs
+          #    this artifact is worth handing to a tester.
+          echo "--- minimum macOS: app binary ---"
+          vtool -show-build "$BIN" 2>/dev/null || otool -l "$BIN" | grep -A4 LC_BUILD_VERSION || true
+          echo "--- minimum macOS: bundled libonnxruntime.dylib ---"
+          vtool -show-build "${APP}/Contents/Frameworks/libonnxruntime.dylib" 2>/dev/null || true
+          echo "--- Homebrew bottle provenance ---"
+          brew info --json=v2 onnxruntime 2>/dev/null | node -e '
+            let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+              try {
+                const f=JSON.parse(s).formulae[0];
+                console.log("onnxruntime", f.versions.stable, "| bottle tags:",
+                  Object.keys(f.bottle?.stable?.files || {}).join(", ") || "(none)");
+              } catch { console.log("(could not parse brew info)"); }
+            });' || true
+
+          echo "--- produced artifacts ---"
+          ls -la "${BUNDLE_DIR}/macos" "${BUNDLE_DIR}/dmg" 2>/dev/null || true
 
       - name: Upload artifacts (macOS)
         if: inputs.upload-artifacts && contains(inputs.platform, 'macos')

--- a/.github/workflows/release-unsigned.yml
+++ b/.github/workflows/release-unsigned.yml
@@ -25,8 +25,12 @@ name: "Release (unsigned)"
 # that release.yml had listed for months without ever building once.
 #
 # Deliberately absent, with reasons (see test-build.yml for the detail):
-#   * Intel macOS — no Intel runner exists since 2025-12-04; cross-compile is
-#     not set up in build.yml.
+#   * Intel macOS — being proven in test-build.yml right now. It is NOT blocked by
+#     tooling: GitHub replaced the retired macos-13 with `macos-15-intel`, which
+#     runs until August 2027 (the earlier "no Intel runner exists" note here was
+#     wrong). It stays out of this matrix until the test build is green AND a
+#     tester confirms the .dmg runs on a real Intel Mac, since no maintainer has
+#     Intel hardware to verify it on.
 #   * ubuntu-22.04 — cannot compile; xcap's pipewire/libspa needs newer libspa
 #     headers than 22.04 ships. The .deb is built on 24.04 instead, so it wants
 #     24.04-era glibc; older distros should use the AppImage.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,12 @@ jobs:
           # Only targets proven green by test-build.yml belong here. Test Build #8
           # showed that Intel macOS, ubuntu-22.04, .rpm and windows-11-arm had all
           # been listed in this matrix without ever building once:
-          #   * Intel macOS — no Intel runner since 2025-12-04; build.yml has no
-          #     macOS cross-compile setup.
+          #   * Intel macOS — being proven in test-build.yml. NOT blocked by
+          #     tooling: GitHub replaced the retired macos-13 with
+          #     `macos-15-intel`, available until August 2027, so the earlier
+          #     "no Intel runner" reasoning here was wrong. Held back until the
+          #     test build is green and a tester confirms it on real Intel
+          #     hardware.
           #   * ubuntu-22.04 — xcap's pipewire/libspa cannot compile against
           #     22.04's older libspa headers (E0560 on spa_video_info_raw.flags).
           #     .deb is built on 24.04 instead.

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,17 +7,13 @@ name: "Test Build"
 # Trigger from the CLI:  gh workflow run test-build.yml --repo <owner>/<repo>
 # or from the Actions tab -> "Test Build" -> "Run workflow".
 #
-# This mirrors the release-unsigned.yml matrix target-for-target, so a green run
-# here means a release will produce the same set of installers. Nothing belongs
-# in a release matrix that has not passed here first — Test Build #8 exposed
-# three targets that release.yml had listed for months without ever building.
+# This is the proving ground for release-unsigned.yml: every target there must
+# have gone green here first — Test Build #8 exposed three targets that
+# release.yml had listed for months without ever building. The reverse does not
+# hold; this matrix may carry extra targets that are still being proven (today:
+# Intel macOS), which is exactly what it is for.
 #
 # Deliberately absent, with reasons (from Test Build #8):
-#
-#   * Intel macOS (x86_64-apple-darwin) — GitHub retired the last Intel macOS
-#     runner (macos-13) on 2025-12-04 and every remaining label is arm64, so it
-#     could only be an arm64->x86_64 cross-compile that build.yml is not set up
-#     for. Never built green.
 #
 #   * ubuntu-22.04 — cannot compile at all. xcap (screen capture) pulls
 #     pipewire/libspa 0.9.2, whose bindings are generated from the system libspa
@@ -36,6 +32,20 @@ name: "Test Build"
 #     Vulkan/SPIRV setup steps in build.yml are gated to non-aarch64 Windows, so
 #     ARM64 never gets an SDK. Needs either an ARM64 Vulkan SDK in CI or a
 #     target-specific opt-out of the vulkan feature.
+#
+# CORRECTION (supersedes the Test Build #8 note that Intel macOS was impossible):
+# GitHub retired `macos-13` on 2025-12-04 but REPLACED it with `macos-15-intel`,
+# which is available until August 2027 (actions/runner-images#13045). The earlier
+# conclusion that every remaining macOS label was arm64 — and therefore that an
+# Intel build could only be a cross-compile — was simply wrong, and the same
+# mistaken premise reached README.md. Intel macOS is now built natively HERE
+# ONLY, as an unproven target. It must go green here, and be confirmed on real
+# Intel hardware by a tester, before it is considered for either release matrix.
+# What it needs beyond a matrix entry (all landed in build.yml / Cargo.toml):
+#   * CPU-only engines — ggml's Metal backend targets Apple Silicon and misbehaves
+#     on Intel GPUs, so Cargo.toml arch-gates `metal` to aarch64.
+#   * Dynamically linked ONNX Runtime from Homebrew, bundled into the .app —
+#     pykeio's `ort` has no prebuilt x86_64-apple-darwin binaries to embed.
 
 on: workflow_dispatch
 
@@ -50,6 +60,13 @@ jobs:
           - platform: "macos-26" # Apple Silicon (M1+)
             args: "--target aarch64-apple-darwin"
             target: "aarch64-apple-darwin"
+          # UNPROVEN — Intel Macs (x86_64), CPU-only. Test-build only; not in any
+          # release matrix until this is green AND a tester confirms it runs on a
+          # real Intel Mac. `fail-fast: false` above keeps a red Intel job from
+          # taking the other four targets down with it.
+          - platform: "macos-15-intel"
+            args: "--target x86_64-apple-darwin"
+            target: "x86_64-apple-darwin"
           - platform: "ubuntu-24.04" # AppImage + .deb, x86_64
             args: "--bundles appimage,deb"
             target: "x86_64-unknown-linux-gnu"

--- a/BUILD.md
+++ b/BUILD.md
@@ -19,7 +19,15 @@ This guide covers how to set up the development environment and build SpeakoFlow
 
 ##### Intel Mac (x86_64)
 
-Prebuilt ONNX Runtime binaries are not available for Intel Macs. Install ONNX Runtime via Homebrew and link dynamically:
+Intel Macs build **CPU-only**. `Cargo.toml` arch-gates the Metal GPU backend to
+Apple Silicon, because ggml's Metal backend targets Apple Silicon and upstream
+whisper.cpp/llama.cpp carry open reports of it (and MoltenVK-Vulkan) producing
+corrupted output or failing to build on Intel Macs. Transcription still works;
+small Whisper models are usable, large ones are slow.
+
+Intel Macs also need one extra step. Prebuilt ONNX Runtime binaries are not
+available for `x86_64-apple-darwin`, because pykeio's `ort` dropped that target, so
+ONNX Runtime has to be installed separately and linked dynamically:
 
 ```bash
 brew install onnxruntime
@@ -31,6 +39,19 @@ The same environment variables apply for production builds:
 ```bash
 ORT_LIB_LOCATION=$(brew --prefix onnxruntime)/lib ORT_PREFER_DYNAMIC_LINK=1 bun run tauri build
 ```
+
+> **This produces an app that only runs on your machine.** Homebrew's dylib
+> records an absolute path into your Cellar as its install name, so the `.app`
+> will fail to start on any Mac without that exact formula installed. That is
+> fine for building for yourself, and it is why CI does it differently: the
+> "Stage ONNX Runtime for Intel macOS" step in
+> [.github/workflows/build.yml](.github/workflows/build.yml) copies the dylib
+> into `src-tauri/onnx-libs/`, rewrites its install name to `@rpath/...` _before_
+> linking, and ships it inside `SpeakoFlow.app/Contents/Frameworks`. Don't
+> distribute a locally built Intel `.dmg`; use a CI artifact.
+
+Intel macOS is currently built in `test-build.yml` only, and is not yet part of
+any release. See [issue #19](https://github.com/AbhishekBarali/SpeakoFlow/issues/19).
 
 #### Windows
 

--- a/README.md
+++ b/README.md
@@ -225,10 +225,20 @@ one case where no **Open Anyway** button appears in _System Settings → Privacy
 Security_. Terminal is the only route left. Proper Apple signing and
 notarization is on the [roadmap](#roadmap) and removes this step entirely.
 
-**Apple Silicon only for now.** Builds cover M1 and newer. There's no Intel Mac
-build, because GitHub retired its Intel build machines in December 2025, so
-there's currently no way to produce and test one. If you're on an Intel Mac you
-can still [build from source](#build-from-source).
+**Apple Silicon only for now.** Builds cover M1 and newer. There's no published
+Intel Mac build yet. Not because it can't be built, but because it hasn't been
+tested on real Intel hardware, and shipping a download that might not start
+would be worse than shipping none. An Intel build is being proven in CI now. If
+it works it will be CPU-only, since the GPU backend targets Apple Silicon. In
+the meantime you can [build from source](#build-from-source), and see
+[BUILD.md](BUILD.md) for the extra Intel step.
+
+> An earlier version of this section said GitHub had retired its Intel build
+> machines, leaving no way to produce or test an Intel build. That was wrong.
+> GitHub retired the old `macos-13` runner in December 2025 but replaced it with
+> `macos-15-intel`, which is available until August 2027. Thanks to
+> [@hellosimplerick](https://github.com/AbhishekBarali/SpeakoFlow/issues/19) for
+> catching it.
 
 </details>
 

--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -9,3 +9,8 @@
 # Native runtime libraries staged by build.rs (transcribe-cpp .dll/.so + VC++
 # redist) for the installer. Regenerated on every build; never committed.
 /transcribe-libs/
+
+# ONNX Runtime dylib staged by CI for the Intel macOS build only (copied from
+# Homebrew, install name rewritten to @rpath, then bundled into the .app). Same
+# deal as transcribe-libs/: regenerated per build, never committed.
+/onnx-libs/

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -146,18 +146,50 @@ transcribe-cpp = { version = "0.1.2", default-features = false, features = [
 [target.'cfg(all(windows, target_arch = "aarch64"))'.dependencies]
 transcribe-cpp = { version = "0.1.2", default-features = false }
 
+# Arch-independent macOS dependencies. The GPU/engine backends are NOT here —
+# they differ by architecture and live in the two tables below, because cargo
+# features are additive and unified: a feature enabled in this table could never
+# be turned back off for one architecture.
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
-transcribe-rs = { version = "0.3.11", features = ["whisper-metal"] }
-# transcribe.cpp macOS: STATIC with the Metal GPU backend compiled in (Apple's
-# default posture). `metal` does NOT imply `shared`, so there are no runtime
-# libs to ship — build.rs staging is a no-op on macOS and nothing is bundled.
-transcribe-cpp = { version = "0.1.2", default-features = false, features = [
-  "metal",
-] }
 # Secure API-key storage via the macOS Keychain. `apple-native` uses the
 # system Security framework (no extra C/system build dependency).
 keyring = { version = "3", features = ["apple-native"] }
+
+# macOS aarch64 (Apple Silicon, M1+) — the shipping macOS target.
+# STATIC with the Metal GPU backend compiled in (Apple's default posture).
+# `metal` does NOT imply `shared`, so there are no runtime libs to ship —
+# build.rs staging is a no-op here and nothing extra is bundled.
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
+transcribe-rs = { version = "0.3.11", features = ["whisper-metal"] }
+transcribe-cpp = { version = "0.1.2", default-features = false, features = [
+  "metal",
+] }
+
+# macOS x86_64 (Intel) — STATIC, CPU-only. Deliberately NO Metal on either
+# engine, for two independent reasons:
+#   * Correctness: ggml's Metal backend targets Apple Silicon. Upstream guidance
+#     for x86_64 macOS is to build with Metal OFF, and llama.cpp/whisper.cpp
+#     carry open reports of Metal (and MoltenVK-Vulkan) producing corrupted
+#     output or failing to build on Intel Macs with AMD/Intel GPUs. A GPU path
+#     that returns garbage transcripts is worse than a slower correct one.
+#   * Hardware spread: Intel Macs span ~2013-2020 with wildly different GPUs, so
+#     there is no single GPU posture that is safe across the fleet.
+# The CPU backend is the portable one, so Intel Macs transcribe on CPU. Small
+# Whisper models are usable; large ones are slow. This is documented in README.
+#
+# This table is explicit even though it matches the backend-less base
+# `[dependencies]` declaration (which already supplies `whisper-cpp` + `onnx`),
+# so the CPU-only posture is recorded and cannot drift silently — same rationale
+# as the Windows-on-ARM table above.
+#
+# NOTE: Intel macOS is also the ONE target where ONNX Runtime is linked
+# DYNAMICALLY rather than statically embedded, because pykeio/ort dropped
+# prebuilt x86_64-apple-darwin binaries. See BUILD.md and the
+# "Stage ONNX Runtime for Intel macOS" step in .github/workflows/build.yml.
+[target.'cfg(all(target_os = "macos", target_arch = "x86_64"))'.dependencies]
+transcribe-rs = { version = "0.3.11", features = ["whisper-cpp"] }
+transcribe-cpp = { version = "0.1.2", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk-layer-shell = { version = "0.8", features = ["v0_6"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -17,10 +17,31 @@ fn main() {
     // -> `usr/lib`, and deb/rpm `/usr/bin/speakoflow` -> `/usr/lib`.
     // transcribe's init_backends_default() then loads the ggml modules
     // co-located there. (Windows resolves DLLs from the exe directory, so it
-    // needs no rpath; macOS links transcribe-cpp statically via the `metal`
-    // feature.)
+    // needs no rpath; macOS links transcribe-cpp statically — Apple Silicon via
+    // the `metal` feature, Intel CPU-only with no features.)
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
         println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../lib");
+    }
+
+    // Intel macOS is the one target that links ONNX Runtime DYNAMICALLY: pykeio's
+    // `ort` dropped prebuilt x86_64-apple-darwin binaries, so transcribe-rs's
+    // `onnx` feature has no static ORT to embed there and CI links against a
+    // Homebrew-provided libonnxruntime instead (see BUILD.md and the
+    // "Stage ONNX Runtime for Intel macOS" step in .github/workflows/build.yml).
+    //
+    // For a *distributable* .dmg that dylib has to travel inside the bundle, in
+    // `SpeakoFlow.app/Contents/Frameworks` (tauri-bundler puts `bundle.macOS.
+    // frameworks` entries there). tauri-bundler explicitly does NOT touch load
+    // paths — embedding the rpath is the caller's job — so bake it in here.
+    //
+    // A no-op for Apple Silicon (static ORT, nothing to resolve) and harmless
+    // for a local Intel dev build, where ORT_LIB_LOCATION points straight at the
+    // Homebrew prefix and the dylib's absolute install name resolves without the
+    // rpath ever being consulted.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos")
+        && std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("x86_64")
+    {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/../Frameworks");
     }
 
     // Stage transcribe-cpp's shared runtime libraries (and the dlopen'd ggml


### PR DESCRIPTION
Closes the factual error reported in #19, and proves an Intel macOS build in CI.

## The wrong claim

The README said GitHub had retired its Intel build machines, so there was "no way
to produce and test" an Intel build. That was false. GitHub retired `macos-13` on
2025-12-04 but replaced it with `macos-15-intel`, available until August 2027
(actions/runner-images#13045). The same mistaken premise had spread into three
workflow files. All corrected, credited to @hellosimplerick.

## Two real obstacles, both handled

**Metal is off on Intel.** ggml's Metal backend targets Apple Silicon, and
upstream whisper.cpp/llama.cpp carry open reports of it producing corrupted output
on Intel Macs with AMD GPUs. The macOS dependency table applied to both
architectures, so Intel was silently inheriting Metal. It is now split by arch and
Intel builds CPU only. Verified per target with `cargo tree`:

| target | transcribe-cpp | transcribe-rs |
| --- | --- | --- |
| aarch64-apple-darwin | `metal` | `whisper-cpp`, `whisper-metal`, `onnx` |
| x86_64-apple-darwin | none, CPU only | `whisper-cpp`, `onnx` |
| x86_64-pc-windows-msvc | `dynamic-backends`, `vulkan` | unchanged |
| x86_64-unknown-linux-gnu | `dynamic-backends`, `vulkan` | unchanged |

Apple Silicon, Windows and Linux resolve identically to before. Note that
`cargo metadata` cannot verify this, as it reports the union across all platforms;
only `cargo tree --target` is per-target.

**ONNX Runtime is bundled.** pykeio's `ort` dropped prebuilt
`x86_64-apple-darwin` binaries, so there is no static ORT to embed there. It also
cannot simply be dropped: `ort` backs `vad-rs` (Silero VAD, used by every
recording) as well as `transcribe-rs` (Parakeet). A Homebrew dylib's install name
is an absolute Cellar path, so linking straight against it produces an app that
only starts on a machine with that formula installed.

CI copies the dylib into `src-tauri/onnx-libs/`, rewrites its install name to
`@rpath` **before** linking, and `bundle.macOS.frameworks` ships it in
`Contents/Frameworks`. `build.rs` emits the matching
`@executable_path/../Frameworks` rpath. Rewriting pre-link avoids post-bundle
surgery on the `.app`, which would leave the generated `.dmg` stale.

## Verified

Test Build [`30976522069`](https://github.com/AbhishekBarali/SpeakoFlow/actions/runs/30976522069)
produced `SpeakoFlow_1.1.0_x64.dmg` and passed all four audit gates:

```
file      -> Mach-O 64-bit executable x86_64
otool -L  -> @rpath/libonnxruntime.dylib (1.28.0), no Homebrew path
LC_RPATH  -> @executable_path/../Frameworks
smoke     -> transcribe.cpp compute devices: 1
```

The smoke test is the meaningful one: it ran on a native Intel runner, and dyld
resolves every linked dylib before `main()`, so the bundled ONNX Runtime genuinely
loaded from inside the app.

## Scope: test-build only

Intel is added to `test-build.yml` and **not** to either release matrix. It stays
out until a tester confirms it runs on real Intel hardware, since no maintainer
has an Intel Mac.

There is also a hard constraint worth recording: Homebrew now publishes an Intel
`onnxruntime` bottle only for Sonoma, and the bundled dylib reports `minos 14.0`,
while the app binary itself is `minos 10.15`. So this build requires **macOS 14 or
newer**, which excludes Intel Macs that cannot reach Sonoma. Lowering that floor
means building ONNX Runtime from source with a lower deployment target. The audit
step prints both minimums and the available bottle tags on every run, so the
constraint is visible rather than assumed.

`macos-15-intel` itself retires in August 2027.

## AI assistance

Investigated and implemented with an AI coding assistant. The runner facts were
verified against GitHub's changelog and `actions/runner-images#13045` rather than
taken from the issue, and the Metal and `ort` constraints were confirmed against
upstream release notes and issues.
