### PR TITLE
fix(assistant): make header controls clickable

### DIFF
--- a/src-tauri/src/assistant.rs
+++ b/src-tauri/src/assistant.rs
@@ -976,7 +976,8 @@ pub fn create_assistant_panel(app: &AppHandle) {
     let (x, y) = saved_position(app).unwrap_or_else(|| default_position(app));
     // Build at whichever size matches the current mode (pill by default) so the
     // first show doesn't briefly flash the large panel before collapsing.
-    let (init_w, init_h) = if PILL_MODE.load(Ordering::SeqCst) {
+    let initially_collapsed = PILL_MODE.load(Ordering::SeqCst);
+    let (init_w, init_h) = if initially_collapsed {
         collapsed_size(app)
     } else {
         expanded_size(app)
@@ -1003,6 +1004,11 @@ pub fn create_assistant_panel(app: &AppHandle) {
     .shadow(false)
     .always_on_top(true)
     .skip_taskbar(true)
+    // The compact voice HUD accepts pointer controls without taking keyboard
+    // focus from the app underneath. Expanding restores focusability for the
+    // prompt input and the rest of the full assistant UI.
+    .focusable(!initially_collapsed)
+    .accept_first_mouse(true)
     .focused(false)
     .visible(false);
 
@@ -1042,6 +1048,7 @@ pub fn show_assistant_panel(app: &AppHandle) {
         // window (showing only the header bar). Re-assert the pill size when
         // collapsed, and always tell the webview which mode to render.
         let collapsed = PILL_MODE.load(Ordering::SeqCst);
+        let _ = window.set_focusable(!collapsed);
         if collapsed {
             let (width, height) = collapsed_size(app);
             let _ = window.set_size(tauri::LogicalSize::new(width, height));
@@ -1166,6 +1173,7 @@ pub fn set_panel_collapsed(app: &AppHandle, collapsed: bool) {
             }
         }
         PILL_MODE.store(collapsed, Ordering::SeqCst);
+        let _ = window.set_focusable(!collapsed);
 
         let (new_w, new_h) = if collapsed {
             collapsed_size(app)

--- a/src/assistant/AssistantPanel.css
+++ b/src/assistant/AssistantPanel.css
@@ -498,6 +498,7 @@
 }
 
 .alive-phase {
+  flex: 1;
   min-width: 0;
   gap: 7px;
   color: var(--as-muted);
@@ -512,8 +513,12 @@
 }
 
 .alive-actions {
+  position: relative;
+  z-index: 2;
   gap: 2px;
   flex-shrink: 0;
+  -webkit-app-region: no-drag;
+  cursor: default;
 }
 
 .alive-button {
@@ -526,6 +531,8 @@
   color: var(--as-muted);
   background: transparent;
   cursor: pointer;
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
 }
 
 .alive-button:hover,
@@ -748,6 +755,15 @@
   font-weight: 600;
   letter-spacing: -0.005em;
   color: var(--as-ink);
+  -webkit-app-region: no-drag;
+  cursor: default;
+}
+
+.assistant-header-drag {
+  align-self: stretch;
+  flex: 1;
+  min-width: 12px;
+  cursor: grab;
 }
 
 .assistant-status-dot {
@@ -803,10 +819,14 @@
 }
 
 .assistant-header-actions {
+  position: relative;
+  z-index: 2;
   display: flex;
   align-items: center;
   gap: 1px;
   flex-shrink: 0;
+  -webkit-app-region: no-drag;
+  cursor: default;
 }
 
 .assistant-icon-button {
@@ -820,6 +840,8 @@
   background: transparent;
   color: var(--as-muted);
   cursor: pointer;
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
   transition:
     background 0.15s ease,
     color 0.15s ease;

--- a/src/assistant/AssistantPanel.tsx
+++ b/src/assistant/AssistantPanel.tsx
@@ -1273,14 +1273,14 @@ const AssistantPanel: React.FC = () => {
       const answer = capturing ? "" : stream || latestAssistant?.content || "";
 
       return (
-        <div className={`${shellClass} live-overlay`} data-tauri-drag-region>
+        <div className={`${shellClass} live-overlay`}>
           <section
             className={`alive-card${isListening ? " listening" : ""}${
               error ? " error" : ""
             }`}
             aria-live="polite"
           >
-            <header className="alive-header" data-tauri-drag-region>
+            <header className="alive-header">
               <div className="alive-phase" data-tauri-drag-region>
                 {isListening ? (
                   <AudioWaveform
@@ -1299,8 +1299,9 @@ const AssistantPanel: React.FC = () => {
                 )}
                 <span data-tauri-drag-region>{pillStatus}</span>
               </div>
-              <div className="alive-actions">
+              <div className="alive-actions" onMouseDown={stopDrag}>
                 <button
+                  type="button"
                   className={`alive-button${ttsEnabled ? " active" : ""}`}
                   onClick={toggleTts}
                   onMouseDown={stopDrag}
@@ -1311,6 +1312,7 @@ const AssistantPanel: React.FC = () => {
                 </button>
                 {locked && isListening && (
                   <button
+                    type="button"
                     className="alive-button"
                     onClick={finishVoice}
                     onMouseDown={stopDrag}
@@ -1322,6 +1324,7 @@ const AssistantPanel: React.FC = () => {
                 )}
                 {showStop && (
                   <button
+                    type="button"
                     className="alive-button danger"
                     onClick={capturing ? cancelVoice : stopTurn}
                     onMouseDown={stopDrag}
@@ -1340,6 +1343,7 @@ const AssistantPanel: React.FC = () => {
                   </button>
                 )}
                 <button
+                  type="button"
                   className="alive-button"
                   onClick={() => collapse(false)}
                   onMouseDown={stopDrag}
@@ -1349,6 +1353,7 @@ const AssistantPanel: React.FC = () => {
                   <Maximize2 size={13} />
                 </button>
                 <button
+                  type="button"
                   className="alive-button danger"
                   onClick={hidePanel}
                   onMouseDown={stopDrag}
@@ -1644,8 +1649,8 @@ const AssistantPanel: React.FC = () => {
             {t("assistant.attach.dropHint")}
           </div>
         )}
-        <div className="assistant-header" data-tauri-drag-region>
-          <div className="assistant-title" data-tauri-drag-region>
+        <div className="assistant-header">
+          <div className="assistant-title">
             <span
               className={`assistant-status-dot${busy ? " busy" : ""}`}
               data-tauri-drag-region
@@ -1688,33 +1693,46 @@ const AssistantPanel: React.FC = () => {
               )}
             </div>
           </div>
+          <div
+            className="assistant-header-drag"
+            data-tauri-drag-region
+            aria-hidden="true"
+          />
           <div className="assistant-header-actions">
             <button
+              type="button"
               className={`assistant-icon-button${ttsEnabled ? " active" : ""}${
                 tts.status === "loading" ? " pulsing" : ""
               }`}
               onClick={toggleTts}
+              onMouseDown={stopDrag}
               title={ttsTitle}
             >
               {ttsEnabled ? <Volume2 size={14} /> : <VolumeX size={14} />}
             </button>
             <button
+              type="button"
               className="assistant-icon-button"
               onClick={clearConversation}
+              onMouseDown={stopDrag}
               title={t("assistant.clear")}
             >
               <Eraser size={14} />
             </button>
             <button
+              type="button"
               className="assistant-icon-button"
               onClick={() => collapse(true)}
+              onMouseDown={stopDrag}
               title={t("assistant.pill.collapse")}
             >
               <Minimize2 size={14} />
             </button>
             <button
+              type="button"
               className="assistant-icon-button close"
               onClick={hidePanel}
+              onMouseDown={stopDrag}
               title={t("assistant.hide")}
             >
               <X size={15} />


### PR DESCRIPTION
## What changed

- keep the Live overlay's speaker, finish, stop, expand, and close controls outside the native drag region
- give the expanded assistant header a dedicated drag handle so its speaker, clear, minimize, close, and character controls receive clicks normally
- keep the collapsed HUD non-focusable while still accepting pointer input, then restore focusability when the full assistant panel is expanded

## Why

The Live and expanded assistant headers were marked as native window-drag regions with their action buttons nested inside. On Linux/Hyprland, the native drag gesture could consume the mouse interaction before React received the click, making the top controls appear present but unusable.

The compact assistant is intentionally an overlay over the user's current app. It should accept a button click without taking keyboard focus away from that app; the expanded panel still needs normal focus for text input.

## Streaming speech

Current `main` already includes the low-latency speech pipeline from `feat(assistant): speak replies as they stream, not after` (#27). It starts TTS from sentence/clause chunks while the LLM response is still arriving and preserves ordering and cancellation. This PR leaves that newer pipeline intact and fixes its HUD controls.

## Checks

- `bun run lint`
- `bun run build`
- `cargo fmt --all -- --check`
- `CMAKE_POLICY_VERSION_MINIMUM=3.5 cargo check --locked --features custom-protocol`
- `cargo clippy --locked --lib --features custom-protocol` (passes with existing repository warnings)
- `cargo test --locked --features custom-protocol speech_stream::tests -- --nocapture` (27 passed)
- `git diff --check`

## AI assistance

AI assistance: Yes. OpenAI Codex was used to diagnose the native drag-region conflict, implement the fix, verify the existing streaming TTS implementation, run checks, and prepare this pull request. The contributor should manually confirm the pointer and focus behavior on Linux/Hyprland before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assistant panel behavior when switching between collapsed and expanded states.
  * Collapsed panels no longer capture focus, while expanded panels remain fully interactive.
  * The panel now responds correctly to the first mouse click.
  * Refined window dragging so header controls and action buttons remain clickable without unintentionally moving the panel.
  * Added a dedicated draggable area for the expanded assistant header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->