### PR TITLE
feat: add Windows SAPI speech output

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -110,6 +110,7 @@ transcribe-rs = { version = "0.3.11", features = ["whisper-vulkan", "ort-directm
 keyring = { version = "3", features = ["windows-native"] }
 windows = { version = "0.61.3", features = [
   "Win32_Media_Audio_Endpoints",
+  "Win32_Media_Speech",
   "Win32_System_Com_StructuredStorage",
   "Win32_System_SystemInformation",
   "Win32_System_Variant",

--- a/src-tauri/src/commands/assistant.rs
+++ b/src-tauri/src/commands/assistant.rs
@@ -430,10 +430,7 @@ pub fn set_assistant_font_size(app: AppHandle, size: String) -> Result<(), Strin
 #[tauri::command]
 #[specta::specta]
 pub fn set_assistant_tts_engine(app: AppHandle, engine: String) -> Result<(), String> {
-    if !matches!(
-        engine.as_str(),
-        "kokoro" | "openai" | "openrouter" | "elevenlabs" | "azure"
-    ) {
+    if !crate::settings::assistant_tts_engine_supported(&engine) {
         return Err(format!("Unknown TTS engine: {}", engine));
     }
     // Switching engine mid-playback should stop the current clip.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,8 @@ mod tray_i18n;
 mod tts;
 mod utils;
 mod web_search;
+#[cfg(windows)]
+mod windows_sapi;
 
 pub use cli::CliArgs;
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1805,6 +1805,15 @@ fn default_assistant_tts_engine() -> String {
     "kokoro".to_string()
 }
 
+pub(crate) fn assistant_tts_engine_supported(engine: &str) -> bool {
+    match engine {
+        "kokoro" | "openai" | "openrouter" | "elevenlabs" | "azure" => true,
+        #[cfg(windows)]
+        "windows" => true,
+        _ => false,
+    }
+}
+
 fn default_assistant_tts_base_url() -> String {
     "https://api.openai.com/v1".to_string()
 }
@@ -2036,10 +2045,7 @@ fn ensure_assistant_defaults(settings: &mut AppSettings) -> bool {
         settings.assistant_tts_voice = default_assistant_tts_voice();
         changed = true;
     }
-    if !matches!(
-        settings.assistant_tts_engine.as_str(),
-        "kokoro" | "openai" | "openrouter" | "elevenlabs" | "azure"
-    ) {
+    if !assistant_tts_engine_supported(&settings.assistant_tts_engine) {
         settings.assistant_tts_engine = default_assistant_tts_engine();
         changed = true;
     }

--- a/src-tauri/src/tts.rs
+++ b/src-tauri/src/tts.rs
@@ -414,8 +414,31 @@ pub(crate) async fn synthesize_speech(
                 bytes,
                 request_id: None,
             }),
+        "windows" => fetch_windows_speech(settings, request.text)
+            .await
+            .map(|bytes| SynthesizedSpeech {
+                bytes,
+                request_id: None,
+            }),
         other => Err(format!("Unknown TTS engine: {}", other)),
     }
+}
+
+/// Render through the default Windows SAPI 5 voice. The work runs on a
+/// dedicated thread because SAPI is a synchronous COM API and requires an
+/// apartment initialized on the calling thread.
+#[cfg(windows)]
+async fn fetch_windows_speech(settings: &AppSettings, text: &str) -> Result<Vec<u8>, String> {
+    let text = text.to_string();
+    let speed = settings.assistant_tts_speed;
+    tauri::async_runtime::spawn_blocking(move || crate::windows_sapi::synthesize(&text, speed))
+        .await
+        .map_err(|e| format!("Windows SAPI task failed: {}", e))?
+}
+
+#[cfg(not(windows))]
+async fn fetch_windows_speech(_settings: &AppSettings, _text: &str) -> Result<Vec<u8>, String> {
+    Err("Windows SAPI is only available on Windows".to_string())
 }
 
 /// Fetch speech audio for `text` using the configured remote engine and play

--- a/src-tauri/src/windows_sapi.rs
+++ b/src-tauri/src/windows_sapi.rs
@@ -1,0 +1,126 @@
+//! Windows Speech API (SAPI 5) synthesis.
+//!
+//! SAPI uses the voice selected in Windows' speech settings, including voices
+//! installed by the system or a SAPI adapter. Audio is rendered to a temporary
+//! WAV file so the existing native playback path can handle cancellation,
+//! output-device selection, and volume consistently with other TTS engines.
+
+#![cfg(windows)]
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use windows::core::PCWSTR;
+use windows::Win32::Media::Speech::{
+    ISpStream, ISpVoice, SpFileStream, SpVoice, SPFM_CREATE_ALWAYS, SPF_IS_NOT_XML,
+};
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
+    COINIT_APARTMENTTHREADED,
+};
+
+/// Synthesize text with the user's default Windows SAPI voice.
+pub fn synthesize(text: &str, speed: f64) -> Result<Vec<u8>, String> {
+    if text.trim().is_empty() {
+        return Err("Windows SAPI cannot synthesize empty text".to_string());
+    }
+
+    let path = temporary_wav_path();
+    let result = synthesize_to_file(text, speed, &path);
+    let audio = result.and_then(|()| {
+        fs::read(&path).map_err(|e| format!("Failed to read Windows SAPI audio: {}", e))
+    });
+    let _ = fs::remove_file(&path);
+    audio
+}
+
+fn synthesize_to_file(text: &str, speed: f64, path: &PathBuf) -> Result<(), String> {
+    let initialized = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+    initialized
+        .ok()
+        .map_err(|e| format!("Could not initialize Windows Speech API COM: {}", e))?;
+
+    struct ComGuard;
+    impl Drop for ComGuard {
+        fn drop(&mut self) {
+            unsafe { CoUninitialize() };
+        }
+    }
+    let _com_guard = ComGuard;
+
+    let path_wide = wide_null(&path.to_string_lossy());
+    let text_wide = wide_null(text);
+
+    let result = (|| unsafe {
+        let stream: ISpStream = CoCreateInstance(&SpFileStream, None, CLSCTX_INPROC_SERVER)
+            .map_err(|e| format!("Could not create Windows SAPI file stream: {}", e))?;
+        stream
+            .BindToFile(
+                PCWSTR(path_wide.as_ptr()),
+                SPFM_CREATE_ALWAYS,
+                None,
+                None,
+                0,
+            )
+            .map_err(|e| format!("Could not open Windows SAPI audio stream: {}", e))?;
+
+        let voice: ISpVoice = CoCreateInstance(&SpVoice, None, CLSCTX_INPROC_SERVER)
+            .map_err(|e| format!("Could not create Windows SAPI voice: {}", e))?;
+        voice
+            .SetOutput(&stream, true)
+            .map_err(|e| format!("Could not configure Windows SAPI output: {}", e))?;
+        voice
+            .SetRate(sapi_rate(speed))
+            .map_err(|e| format!("Could not configure Windows SAPI speaking rate: {}", e))?;
+        voice
+            .Speak(PCWSTR(text_wide.as_ptr()), SPF_IS_NOT_XML.0 as u32, None)
+            .map_err(|e| format!("Windows SAPI synthesis failed: {}", e))?;
+        stream
+            .Close()
+            .map_err(|e| format!("Could not close Windows SAPI audio stream: {}", e))?;
+
+        // SAPI finishes synchronous Speak before returning. Drop the COM
+        // objects before reading so the file handle is closed and all bytes
+        // are flushed.
+        drop(voice);
+        drop(stream);
+        Ok(())
+    })();
+
+    result
+}
+
+/// Map the app's 0.25x–4x multiplier to SAPI's -10…10 rate adjustment.
+fn sapi_rate(speed: f64) -> i32 {
+    (((speed.clamp(0.25, 4.0) - 1.0) * 10.0).round() as i32).clamp(-10, 10)
+}
+
+fn temporary_wav_path() -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    std::env::temp_dir().join(format!(
+        "speakoflow-sapi-{}-{}.wav",
+        std::process::id(),
+        stamp
+    ))
+}
+
+fn wide_null(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sapi_rate;
+
+    #[test]
+    fn speed_maps_to_sapi_rate_range() {
+        assert_eq!(sapi_rate(0.25), -8);
+        assert_eq!(sapi_rate(1.0), 0);
+        assert_eq!(sapi_rate(2.0), 10);
+        assert_eq!(sapi_rate(4.0), 10);
+    }
+}

--- a/src/components/settings/assistant/AssistantSettings.tsx
+++ b/src/components/settings/assistant/AssistantSettings.tsx
@@ -46,6 +46,7 @@ import "../../../assistant/AssistantPanel.css";
 import { useModelStore } from "@/stores/modelStore";
 import { getModelCategory } from "@/lib/utils/modelCategory";
 import { useLocalLlmEngineStatus } from "@/hooks/useLocalLlmEngineStatus";
+import { useOsType } from "@/hooks/useOsType";
 import ScreenRecordingPermission from "@/components/ScreenRecordingPermission";
 
 /** The built-in (local) llama.cpp provider id, mirrored from the backend. */
@@ -178,6 +179,8 @@ export const AssistantSettings: React.FC<AssistantSettingsProps> = ({
   } = useSettings();
 
   const providers = settings?.post_process_providers || [];
+  const osType = useOsType();
+  const isWindows = osType === "windows";
   const selectedProviderId = settings?.assistant_provider_id || "custom";
   const selectedProvider = providers.find((p) => p.id === selectedProviderId);
 
@@ -1154,6 +1157,14 @@ export const AssistantSettings: React.FC<AssistantSettingsProps> = ({
                     value: "azure",
                     label: t("settings.assistant.tts.engines.azure"),
                   },
+                  ...(isWindows
+                    ? [
+                        {
+                          value: "windows",
+                          label: t("settings.assistant.tts.engines.windows"),
+                        },
+                      ]
+                    : []),
                 ]}
                 selectedValue={settings?.assistant_tts_engine ?? "kokoro"}
                 onSelect={(engine) => {
@@ -1497,6 +1508,19 @@ export const AssistantSettings: React.FC<AssistantSettingsProps> = ({
                   />
                 </SettingContainer>
               </>
+            )}
+
+            {settings?.assistant_tts_engine === "windows" && (
+              <SettingContainer
+                title={t("settings.assistant.tts.windowsVoiceLabel")}
+                info={t("settings.assistant.tts.windowsVoiceDescription")}
+                layout="horizontal"
+                grouped={true}
+              >
+                <span className="text-[13px] text-muted">
+                  {t("settings.assistant.tts.windowsVoiceInstalled")}
+                </span>
+              </SettingContainer>
             )}
 
             <SettingContainer

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1308,7 +1308,8 @@
           "openai": "OpenAI-compatible",
           "openrouter": "OpenRouter",
           "elevenlabs": "ElevenLabs",
-          "azure": "Azure AI Speech"
+          "azure": "Azure AI Speech",
+          "windows": "Windows SAPI (system)"
         },
         "voiceLabel": "Voice",
         "voiceDescription": "Kokoro voice for spoken replies.",
@@ -1340,6 +1341,9 @@
         "remoteVoiceDescription": "Voice for OpenAI-compatible TTS, e.g. alloy, echo, nova, shimmer.",
         "azureVoiceLabel": "Voice name",
         "azureVoiceDescription": "Azure voice name, e.g. en-US-JennyNeural. Click Load voices to browse.",
+        "windowsVoiceLabel": "Windows voice",
+        "windowsVoiceDescription": "Uses the default voice selected in Windows Speech settings, including installed SAPI voices. No API key or internet connection is required.",
+        "windowsVoiceInstalled": "Uses your Windows default voice",
         "loadVoices": "Load voices",
         "voicesLoading": "Loading…",
         "voicesPick": "Pick from {{count}} voices…",


### PR DESCRIPTION
Closes #29

## Summary
- add a Windows-only SAPI 5 TTS engine that uses the voice selected in Windows Speech settings
- render SAPI output to a temporary WAV and reuse the existing playback path for cancellation, volume, and output-device handling
- expose the engine only on Windows and keep non-Windows engine validation unchanged

## Testing
- `cargo fmt -- --check` (pass)
- standalone Windows SAPI API compile with `rustup run stable-x86_64-pc-windows-gnu cargo check --offline` (pass)
- full `cargo check --lib` could not complete because the environment could not fetch dependencies (`cpal 0.16.0` offline; online `cargo fetch` timed out after 604s)
- frontend build not run: Bun is not installed and `node_modules` is absent

## AI assistance disclosure
- AI used: yes
- Tool: ChatGPT/Codex
- Extent: implementation assistance, API investigation, and validation support; all changes were reviewed in the repository context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows SAPI as a text-to-speech engine.
  * Windows users can use their installed default voice for offline speech synthesis without an API key.
  * Added localized settings information for the Windows voice option.

* **Bug Fixes**
  * Improved validation of supported text-to-speech engines across platforms.
  * Selecting Windows SAPI on unsupported platforms now reports an appropriate error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->