### PR TITLE
feat: add Novita AI as a post-processing provider

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1522,6 +1522,14 @@ fn default_post_process_providers() -> Vec<PostProcessProvider> {
             supports_structured_output: false,
         },
         PostProcessProvider {
+            id: "novita".to_string(),
+            label: "Novita AI".to_string(),
+            base_url: "https://api.novita.ai/openai/v1".to_string(),
+            allow_base_url_edit: false,
+            models_endpoint: Some("/models".to_string()),
+            supports_structured_output: false,
+        },
+        PostProcessProvider {
             id: "perplexity".to_string(),
             label: "Perplexity".to_string(),
             base_url: "https://api.perplexity.ai".to_string(),


### PR DESCRIPTION

## Summary

Adds Novita AI to the built-in cloud provider table used for LLM post-processing (cleanup/translation), alongside the other OpenAI-compatible gateways already listed (Groq, Together, Fireworks, etc).

## Changes

- `src-tauri/src/settings.rs`: added a `novita` entry to `default_post_process_providers()` — `base_url: https://api.novita.ai/openai/v1`, `models_endpoint: /models`, `allow_base_url_edit: false`, `supports_structured_output: false` (Novita is a multi-model marketplace, so structured-output support varies by model, same reasoning as the existing Groq/Together/Fireworks entries).

Novita's endpoint is OpenAI-compatible and needs no special-casing in `llm_client.rs` — it already sends plain `Authorization: Bearer` auth against `/chat/completions` and `/models` for any provider that isn't `anthropic` or an Azure base URL, which covers Novita as-is.

## Verification

- Confirmed via source read that `llm_client.rs`'s default auth/request path (Bearer token, `/chat/completions`, `/models`) applies to the new entry without modification.
- Live request against `https://api.novita.ai/openai/v1/models` returned HTTP 200 with the model catalog.
- A real chat-completion request through the same header/path convention the app uses (`Authorization: Bearer`, `Content-Type`, etc.) returned HTTP 200 with a valid response and `finish_reason: stop`.
- The diff is additive only (+8 lines) and doesn't touch any other provider or code path.

## AI Assistance Disclosure

- AI used: yes.
- Tool: AI coding assistant.
- How extensively: used to draft this change — a single provider table entry following the existing pattern for other OpenAI-compatible providers in the same file, and to run the verification steps above.
